### PR TITLE
Hotfix: shared/ mount in deploy + production compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,9 +101,13 @@ jobs:
           # because the bind mount is of the parent dir's symlink target.
           # Safer approach: docker run a fresh ephemeral container with the new
           # release bind-mounted directly.
+          # The ephemeral containers must also see $PROJECT_ROOT/shared at the
+          # absolute path the symlinks point at, otherwise .env and storage/
+          # are dangling and Laravel boot fails.
           echo "::group::composer install (--no-dev)"
           docker run --rm \
             -v "$PROJECT_ROOT/$RELEASE_PATH:/var/www" \
+            -v "$PROJECT_ROOT/shared:$PROJECT_ROOT/shared" \
             -w /var/www \
             --user "$(id -u):$(id -g)" \
             laravel-app \
@@ -113,6 +117,7 @@ jobs:
           echo "::group::npm ci && npm run build"
           docker run --rm \
             -v "$PROJECT_ROOT/$RELEASE_PATH:/var/www" \
+            -v "$PROJECT_ROOT/shared:$PROJECT_ROOT/shared" \
             -w /var/www \
             --user "$(id -u):$(id -g)" \
             laravel-app \

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -22,6 +22,7 @@ services:
     working_dir: /var/www
     volumes:
       - ./current:/var/www
+      - ./shared:/opt/projects/norman_database_system/shared
       - ./current/_php/local.ini:/usr/local/etc/php/conf.d/local.ini
     networks:
       - mkassets_docker_network
@@ -38,6 +39,7 @@ services:
     tty: true
     volumes:
       - ./current:/var/www
+      - ./shared:/opt/projects/norman_database_system/shared
       - ./current/_php/local.ini:/usr/local/etc/php/conf.d/local.ini
     networks:
       - mkassets_docker_network
@@ -60,6 +62,7 @@ services:
       start_period: 30s
     volumes:
       - ./current:/var/www
+      - ./shared:/opt/projects/norman_database_system/shared
       - ./current/_php/local.ini:/usr/local/etc/php/conf.d/local.ini
     networks:
       - mkassets_docker_network
@@ -91,6 +94,7 @@ services:
       start_period: 60s
     volumes:
       - ./current:/var/www
+      - ./shared:/opt/projects/norman_database_system/shared
       - ./current/_php/export-worker.ini:/usr/local/etc/php/conf.d/export-worker.ini
     networks:
       - mkassets_docker_network
@@ -113,6 +117,7 @@ services:
       start_period: 30s
     volumes:
       - ./current:/var/www
+      - ./shared:/opt/projects/norman_database_system/shared
       - ./current/_php/local.ini:/usr/local/etc/php/conf.d/local.ini
     networks:
       - mkassets_docker_network
@@ -127,6 +132,7 @@ services:
       - LETSENCRYPT_HOST=nds.mkassets.sk,norman-databases.org,www.norman-databases.org
     volumes:
       - ./current:/var/www
+      - ./shared:/opt/projects/norman_database_system/shared
       - ./current/nginx/conf.d/:/etc/nginx/conf.d/
     networks:
       - mkassets_docker_network


### PR DESCRIPTION
The bootstrap symlinks (.env, storage) point at absolute host paths under /opt/projects/norman_database_system/shared/. Containers that only mount ./current see those symlinks as dangling, breaking Laravel boot.

Fixes both surfaces:
- docker-compose.production.yml: adds the shared mount to all 6 services (matches the manual fix already applied to the host docker-compose.yml during go-live)
- .github/workflows/deploy.yml: adds the shared mount to the ephemeral docker run commands for composer install and npm build

Production runtime is already fixed manually. This PR aligns the repo with the running state and unblocks the auto-deploy pipeline.