### PR TITLE
Pivot tests to Postgres and fix stale Breeze tests

### DIFF
--- a/database/factories/Susdat/SubstanceFactory.php
+++ b/database/factories/Susdat/SubstanceFactory.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Database\Factories;
+namespace Database\Factories\Susdat;
 
 use App\Models\Susdat\Substance;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class SubstanceFactory extends Factory
@@ -43,7 +44,7 @@ class SubstanceFactory extends Factory
             'metadata_cas' => [],
             'metadata_ms_ready' => [],
             'metadata_general' => [],
-            'added_by' => 1,
+            'added_by' => User::factory(),
         ];
     }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -315,8 +315,27 @@ This guard exists because the live `nds` database was wiped once by a stray `mig
 (Brief — full setup belongs in the README. This is the deploy-relevant part.)
 
 - Local dev uses the repo's `docker-compose.yml`, NOT `docker-compose.production.yml`.
-- `php artisan test` runs against in-memory SQLite — no postgres needed locally.
 - Your local `.env` is yours, not committed. Use `.env.example` as a starting point.
+
+### One-time test database setup
+
+Tests run against a real PostgreSQL database (matches production). Each developer needs an empty `norman_test` database in their local Postgres instance — same host/port/user as the dev `nds` database.
+
+```bash
+psql -h 127.0.0.1 -p 5433 -U app -d nds -c "CREATE DATABASE norman_test OWNER app;"
+```
+
+(Adjust `-h`, `-p`, `-U` to match your local Postgres if different. The default in `phpunit.xml` is `127.0.0.1:5433` with user `app`.)
+
+That's all. The `tests/TestCase.php` guard already permits any database name starting with `norman_test`, so you're protected from a stray `migrate:fresh` accidentally hitting your dev `nds` database.
+
+Run tests with:
+
+```bash
+php artisan test
+```
+
+Each run starts with a clean schema (`RefreshDatabase` trait drops and recreates tables). Your `nds` dev database is never touched.
 
 ---
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,12 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="pgsql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="5433"/>
+        <env name="DB_DATABASE" value="norman_test"/>
+        <env name="DB_USERNAME" value="app"/>
+        <env name="DB_PASSWORD" value="password"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -27,7 +27,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('home', absolute: false));
     }
 
     public function test_users_can_not_authenticate_with_invalid_password(): void

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -18,8 +18,12 @@ class RegistrationTest extends TestCase
 
     public function test_new_users_can_register(): void
     {
+        // RegisteredUserController requires the 'user' role to exist (assigned at registration).
+        \Spatie\Permission\Models\Role::firstOrCreate(['name' => 'user']);
+
         $response = $this->post('/register', [
-            'name' => 'Test User',
+            'first_name' => 'Test',
+            'last_name' => 'User',
             'email' => 'test@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -28,7 +28,8 @@ class ProfileTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->patch('/profile', [
-                'name' => 'Test User',
+                'first_name' => 'Test',
+                'last_name' => 'User',
                 'email' => 'test@example.com',
             ]);
 
@@ -38,7 +39,8 @@ class ProfileTest extends TestCase
 
         $user->refresh();
 
-        $this->assertSame('Test User', $user->name);
+        $this->assertSame('Test', $user->first_name);
+        $this->assertSame('User', $user->last_name);
         $this->assertSame('test@example.com', $user->email);
         $this->assertNull($user->email_verified_at);
     }
@@ -50,7 +52,8 @@ class ProfileTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->patch('/profile', [
-                'name' => 'Test User',
+                'first_name' => 'Test',
+                'last_name' => 'User',
                 'email' => $user->email,
             ]);
 

--- a/tests/Feature/SusdatMissingNamesTest.php
+++ b/tests/Feature/SusdatMissingNamesTest.php
@@ -6,7 +6,7 @@ namespace Tests\Feature;
 
 use App\Models\Susdat\Substance;
 use App\Models\User;
-use Database\Factories\SubstanceFactory;
+use Database\Factories\Susdat\SubstanceFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;


### PR DESCRIPTION
Tests now run against a real Postgres norman_test database instead of SQLite in-memory. Removes the burden of guarding every pg-specific migration. Result: 44 passed, 1 skipped (data-dependent), down from 12 passing on SQLite. Local devs need a one-time 'CREATE DATABASE norman_test' — documented in CONTRIBUTING.md section 10.