### PR TITLE
Add Tests job to CI with Postgres service container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,18 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Build frontend assets
+        run: npm run build
+
       - name: Prepare environment
         run: |
           cp .env.example .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,49 @@ jobs:
 
       - name: Build assets
         run: npm run build
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: norman_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_pgsql, pgsql, mbstring, xml, bcmath, gd, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Prepare environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Run tests
+        run: php artisan test

--- a/tests/Feature/Empodat/CleanupExpiredExportsTest.php
+++ b/tests/Feature/Empodat/CleanupExpiredExportsTest.php
@@ -16,30 +16,16 @@ use Tests\TestCase;
  */
 class CleanupExpiredExportsTest extends TestCase
 {
-    private string $sandboxDir;
+    private string $sandboxDir = '';
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        // ExportDownload writes go through the default Laravel connection,
-        // which phpunit.xml points at sqlite/:memory:. Restore the real
-        // database so the model can read/write the export_downloads table.
-        $database = $this->resolveRealPostgresDatabase();
-        if ($database === null) {
-            $this->markTestSkipped(
-                'Cannot resolve a real PostgreSQL database (read .env DB_DATABASE or set TEST_PG_DATABASE).'
-            );
-        }
-
-        config([
-            'database.default' => 'pgsql',
-            'database.connections.pgsql.database' => $database,
-        ]);
-        DB::purge('pgsql');
-
+        // The phpunit.xml default connection is now Postgres (norman_test) —
+        // ExportDownload reads/writes go through it directly, no manual switch needed.
         try {
-            DB::connection('pgsql')->getPdo();
+            DB::connection()->getPdo();
         } catch (\Throwable $e) {
             $this->markTestSkipped('Cannot connect to PostgreSQL: '.$e->getMessage());
         }
@@ -52,9 +38,11 @@ class CleanupExpiredExportsTest extends TestCase
 
     protected function tearDown(): void
     {
-        DB::rollBack();
+        if (DB::transactionLevel() > 0) {
+            DB::rollBack();
+        }
 
-        if (is_dir($this->sandboxDir)) {
+        if ($this->sandboxDir !== '' && is_dir($this->sandboxDir)) {
             foreach (glob($this->sandboxDir.'/*') as $f) {
                 @unlink($f);
             }

--- a/tests/Feature/Empodat/EmpodatCsvExportPipelineTest.php
+++ b/tests/Feature/Empodat/EmpodatCsvExportPipelineTest.php
@@ -19,29 +19,13 @@ use Tests\TestCase;
  */
 class EmpodatCsvExportPipelineTest extends TestCase
 {
-    /**
-     * phpunit.xml overrides DB_DATABASE to ":memory:" for the sqlite default.
-     * The streaming code targets the named "pgsql" connection (which still
-     * pulls DB_DATABASE from env), so restore the real database name from
-     * the project's .env before each test.
-     */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $database = $this->resolveRealPostgresDatabase();
-
-        if ($database === null) {
-            $this->markTestSkipped(
-                'Cannot resolve a real PostgreSQL database (read .env DB_DATABASE or set TEST_PG_DATABASE).'
-            );
-        }
-
-        config(['database.connections.pgsql.database' => $database]);
-        DB::purge('pgsql');
-
+        // Default connection is now Postgres (norman_test) per phpunit.xml.
         try {
-            DB::connection('pgsql')->getPdo();
+            DB::connection()->getPdo();
         } catch (\Throwable $e) {
             $this->markTestSkipped('Cannot connect to PostgreSQL: '.$e->getMessage());
         }


### PR DESCRIPTION
Adds a Tests job to .github/workflows/ci.yml. Spins up postgres:16 as a service container (mapped to host port 5433 to match phpunit.xml), installs deps, runs php artisan test. The Tests job runs on this PR — if it goes green here, the job works. After merge, add 'Tests' to required status checks for main and development.