### PR TITLE
Add BlackSea suspect-screening import + empodat_suspect_metadata side-table

### DIFF
--- a/database/migrations/2026_05_21_120000_create_empodat_suspect_metadata_table.php
+++ b/database/migrations/2026_05_21_120000_create_empodat_suspect_metadata_table.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Creates `empodat_suspect_metadata` as a PostgreSQL list-partitioned side
+     * table for HRMS identification metadata that the legacy `empodat_suspect_main`
+     * schema does not capture (introduced for BlackSea / NKUA-format sources).
+     *
+     * Design:
+     * - `id` mirrors `empodat_suspect_main.id` 1:1 (NOT auto-increment; populated
+     *   by the per-source MainSeeder which captures the inserted main IDs).
+     * - Partitioned LIST on `is_numeric_concentration` to match the parent table's
+     *   partition layout, so a metadata row always lives in the same partition as
+     *   its corresponding main row.
+     * - No DB-level FK to `empodat_suspect_main` by design — referential integrity
+     *   is enforced by the seeder (cross-partition FKs are awkward in PostgreSQL
+     *   and we prefer schema simplicity here).
+     * - Only sources whose XLSX includes the HRMS metadata block populate this
+     *   table (BlackSea: yes; legacy 8: no; TerraChem: TBD).
+     */
+    public function up(): void
+    {
+        DB::statement('
+            CREATE TABLE empodat_suspect_metadata (
+                id BIGINT NOT NULL,
+                is_numeric_concentration BOOLEAN NOT NULL,
+                method VARCHAR(64) NULL,
+                mz_score DOUBLE PRECISION NULL,
+                isotopicfit_score DOUBLE PRECISION NULL,
+                numoffragments_score DOUBLE PRECISION NULL,
+                ddamsms_score DOUBLE PRECISION NULL,
+                molecularfitfragments_score DOUBLE PRECISION NULL,
+                rti_score DOUBLE PRECISION NULL,
+                spectral_similarity DOUBLE PRECISION NULL,
+                rt_avg DOUBLE PRECISION NULL,
+                fragments TEXT NULL,
+                based_on_similarity TEXT NULL,
+                based_on_compound TEXT NULL,
+                identification_proofs TEXT NULL,
+                num_fragments DOUBLE PRECISION NULL,
+                PRIMARY KEY (id, is_numeric_concentration)
+            ) PARTITION BY LIST (is_numeric_concentration)
+        ');
+
+        DB::statement('
+            CREATE TABLE empodat_suspect_metadata_numeric
+                PARTITION OF empodat_suspect_metadata
+                FOR VALUES IN (TRUE)
+        ');
+
+        DB::statement('
+            CREATE TABLE empodat_suspect_metadata_nonnumeric
+                PARTITION OF empodat_suspect_metadata
+                FOR VALUES IN (FALSE)
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Drops both partitions via CASCADE on the parent.
+     */
+    public function down(): void
+    {
+        DB::statement('DROP TABLE IF EXISTS empodat_suspect_metadata CASCADE');
+    }
+};

--- a/database/migrations/2026_05_21_140000_fix_empodat_suspect_station_filters_unique_index_for_concurrent_refresh.php
+++ b/database/migrations/2026_05_21_140000_fix_empodat_suspect_station_filters_unique_index_for_concurrent_refresh.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Replaces the expression-based unique index on `empodat_suspect_station_filters`
+     * with a plain-column unique index so that REFRESH MATERIALIZED VIEW CONCURRENTLY
+     * works.
+     *
+     * Background: the previous index used COALESCE(...) wrappers to deal with
+     * potentially-NULL columns:
+     *
+     *   CREATE UNIQUE INDEX idx_essf_unique_combo
+     *     ON empodat_suspect_station_filters
+     *     USING btree (
+     *       station_id,
+     *       COALESCE(country_id, 0::bigint),
+     *       COALESCE(matrix_id, 0::bigint),
+     *       COALESCE(sampling_date_year::integer, 0)
+     *     );
+     *
+     * PostgreSQL classifies that as an "expression index" and refuses to use it
+     * for CONCURRENT refresh:
+     *
+     *   ERROR:  cannot refresh materialized view ... concurrently
+     *   HINT:   Create a unique index with no WHERE clause on one or more columns
+     *           of the materialized view.
+     *
+     * Verified before this migration: 0 NULLs in any of (station_id, country_id,
+     * matrix_id, sampling_date_year) and 0 duplicate combos, so a plain-column
+     * unique index works for the actual data.
+     */
+    public function up(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS idx_essf_unique_combo');
+
+        DB::statement('
+            CREATE UNIQUE INDEX idx_essf_unique_combo
+                ON empodat_suspect_station_filters
+                USING btree (station_id, country_id, matrix_id, sampling_date_year)
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Restores the original COALESCE-based unique index. Note: doing this also
+     * re-introduces the CONCURRENT-refresh limitation.
+     */
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS idx_essf_unique_combo');
+
+        DB::statement('
+            CREATE UNIQUE INDEX idx_essf_unique_combo
+                ON empodat_suspect_station_filters
+                USING btree (
+                    station_id,
+                    COALESCE(country_id, 0::bigint),
+                    COALESCE(matrix_id, 0::bigint),
+                    COALESCE(sampling_date_year::integer, 0)
+                )
+        ');
+    }
+};

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the BlackSea BIOTA source file (id=10009) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the BlackSea BIOTA pipeline only.
+ * Called by EmpodatSuspectBlackSeaBiotaSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectBlackSeaBiotaFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10009],
+            [
+                'original_name' => 'DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'name' => 'BlackSea 2025 BIOTA Suspect Screening Results',
+                'description' => 'NKUA — BlackSea 2025 suspect screening, BIOTA matrix (wet weight, μg/kg ww). Includes HRMS identification metadata (mz score, RTI, fragments, etc.) stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaMainSeeder.php
@@ -113,8 +113,16 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
 
-        $this->command->info('Streaming BlackSea BIOTA → empodat_suspect_main + empodat_suspect_metadata (file_id='
+        $this->command->info('Streaming BlackSea BIOTA → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');
+
+        // Pre-load already-registered substances for this file so we don't re-insert duplicates.
+        $existingSubstances = DB::table('empodat_suspect_substances')
+            ->where('file_id', self::FILE_ID)
+            ->pluck('norman_id')
+            ->map(fn (?string $v): string => (string) $v)
+            ->flip()
+            ->all();
 
         $reader = SimpleExcelReader::create($path);
 
@@ -122,6 +130,7 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
         $stationCols = [];
         $mainBatch = [];
         $metadataBatch = [];
+        $substancesByKey = []; // collected during the single xlsx pass, inserted at the end
         $rowCount = 0;
         $insertedMain = 0;
         $skippedSourceRows = 0;
@@ -139,7 +148,7 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
                 $rowCount++;
 
                 try {
-                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols);
+                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols, $substancesByKey, $existingSubstances);
                 } catch (\Throwable $e) {
                     $skippedSourceRows++;
                     if ($skippedSourceRows <= 10) {
@@ -175,6 +184,9 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
                 $this->flushBatch($mainBatch, $metadataBatch);
                 $insertedMain += count($mainBatch);
             }
+
+            // Bulk insert collected substances (single pass — replaces the standalone SubstancesSeeder).
+            $insertedSubstances = $this->insertSubstances($substancesByKey);
         } finally {
             DB::statement('SET session_replication_role = default;');
             DB::connection()->enableQueryLog();
@@ -184,7 +196,7 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
         }
 
         $totalTime = round(microtime(true) - $startTime, 2);
-        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows.");
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows, {$insertedSubstances} substances.");
         if ($skippedSourceRows > 0) {
             $this->command->warn("Skipped {$skippedSourceRows} source rows due to errors.");
         }
@@ -193,7 +205,8 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
     }
 
     /**
-     * Build the main + metadata rows for a single source row.
+     * Build the main + metadata rows for a single source row, and accumulate
+     * the per-file substance record (norman_id, name) for end-of-run bulk insert.
      *
      * Returns: [array<int, array> $mainRows, array $metadataPayloadCommonFields].
      * Each main row's `is_numeric_concentration` is then attached to the corresponding
@@ -201,13 +214,26 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
      *
      * @param  array<string, mixed>  $sourceRow
      * @param  array<int, string>  $stationCols
+     * @param  array<string, array<string, mixed>>  $substancesByKey  accumulator, keyed by 'normanId|name'
+     * @param  array<string, int>  $existingSubstances  norman_id => 1 lookup for already-registered substances
      * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
      */
-    protected function buildRows(array $sourceRow, array $stationCols): array
+    protected function buildRows(array $sourceRow, array $stationCols, array &$substancesByKey, array $existingSubstances): array
     {
         $normanId = $this->cleanString($sourceRow['NORMAN_ID'] ?? null);
         if ($normanId === null) {
             return [[], []];
+        }
+
+        // Collect substance record for this file (deduped, inserted in bulk at end of run).
+        $name = $this->cleanString($sourceRow['Name'] ?? null);
+        if ($name !== null && ! isset($existingSubstances[$normanId])) {
+            $key = $normanId.'|'.$name;
+            $substancesByKey[$key] ??= [
+                'norman_id' => $normanId,
+                'name' => $name,
+                'file_id' => self::FILE_ID,
+            ];
         }
 
         // Strip NS prefix, normalize, resolve to susdat_substances.id
@@ -312,6 +338,29 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
             }
             DB::table('empodat_suspect_metadata')->insert($metadataInsert);
         });
+    }
+
+    /**
+     * Bulk-insert the per-file substance records collected during the streaming pass.
+     * Already-existing (norman_id, file_id) rows were filtered out during collection,
+     * so this is a straight chunked INSERT.
+     *
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     */
+    protected function insertSubstances(array $substancesByKey): int
+    {
+        if (empty($substancesByKey)) {
+            return 0;
+        }
+
+        $rows = array_values($substancesByKey);
+        $inserted = 0;
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('empodat_suspect_substances')->insert($chunk);
+            $inserted += count($chunk);
+        }
+
+        return $inserted;
     }
 
     /**

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaMainSeeder.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Database\Seeders\EmpodatSuspect\Traits\LoadsSubstanceCaches;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Stream BlackSea BIOTA xlsx → populate both `empodat_suspect_main` and
+ * the new `empodat_suspect_metadata` side table in a single pass.
+ *
+ * Per source row:
+ *   - extract Block A/B/C fields (substance, IP, Units, …)
+ *   - extract Block E fields (13 HRMS metadata columns)
+ *   - find station columns (after `Units`, before `mz score`)
+ *   - for each non-NA station value: spawn one `empodat_suspect_main` row,
+ *     capture the returned id, spawn matching `empodat_suspect_metadata` row
+ *     with the same id + is_numeric_concentration (so both rows live in the
+ *     same partition).
+ *
+ * Metadata rows are 1:1 with main rows by id (no DB-level FK — enforced here).
+ * The same metadata values repeat across the N main rows spawned from one
+ * source row — by design (per plan doc §3a).
+ *
+ * Performance: true streaming (no getRows()->toArray()), batched inserts of
+ * 500 rows. PostgreSQL RETURNING preserves insert order across partitions.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (column-by-column log)
+ */
+class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
+{
+    use LoadsSubstanceCaches;
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10009;
+
+    protected const FILE_NAME = 'DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    /** Structural marker — station columns begin after this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker — HRMS metadata block begins at this column. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    /** Block E (HRMS metadata) column names in source-file order. */
+    protected const METADATA_COLUMNS = [
+        'mz score',
+        'isotopicfit score',
+        'numoffragments score',
+        'DDAMSMS score',
+        'molecularfitfragments score',
+        'rti score',
+        'spectral similarity',
+        'RT avg',
+        'Fragments',
+        'Based_on_similarity',
+        'Based_on_compound',
+        'Identification_Proofs',
+        'NumFragments',
+    ];
+
+    /** Source-column → empodat_suspect_metadata column name map (for Block E). */
+    protected const METADATA_COLUMN_MAP = [
+        'mz score' => 'mz_score',
+        'isotopicfit score' => 'isotopicfit_score',
+        'numoffragments score' => 'numoffragments_score',
+        'DDAMSMS score' => 'ddamsms_score',
+        'molecularfitfragments score' => 'molecularfitfragments_score',
+        'rti score' => 'rti_score',
+        'spectral similarity' => 'spectral_similarity',
+        'RT avg' => 'rt_avg',
+        'Fragments' => 'fragments',
+        'Based_on_similarity' => 'based_on_similarity',
+        'Based_on_compound' => 'based_on_compound',
+        'Identification_Proofs' => 'identification_proofs',
+        'NumFragments' => 'num_fragments',
+    ];
+
+    /** Columns stored as double precision in empodat_suspect_metadata. */
+    protected const METADATA_DOUBLE_COLUMNS = [
+        'mz_score', 'isotopicfit_score', 'numoffragments_score', 'ddamsms_score',
+        'molecularfitfragments_score', 'rti_score', 'spectral_similarity', 'rt_avg',
+        'num_fragments',
+    ];
+
+    /** Number of main+metadata rows per insert batch. */
+    protected const BATCH_SIZE = 500;
+
+    public function run(): void
+    {
+        ini_set('memory_limit', '4G');
+        ini_set('max_execution_time', '7200');
+
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Loading lookup caches...');
+        $this->loadLookupCaches();
+
+        // Disable Telescope + query log during bulk insert
+        if (class_exists(\Laravel\Telescope\Telescope::class)) {
+            \Laravel\Telescope\Telescope::stopRecording();
+        }
+        DB::connection()->disableQueryLog();
+        DB::statement('SET session_replication_role = replica;');
+
+        $this->command->info('Streaming BlackSea BIOTA → empodat_suspect_main + empodat_suspect_metadata (file_id='
+            .self::FILE_ID.')...');
+
+        $reader = SimpleExcelReader::create($path);
+
+        $header = null;
+        $stationCols = [];
+        $mainBatch = [];
+        $metadataBatch = [];
+        $rowCount = 0;
+        $insertedMain = 0;
+        $skippedSourceRows = 0;
+        $startTime = microtime(true);
+        $lastReport = $startTime;
+
+        try {
+            foreach ($reader->getRows() as $sourceRow) {
+                if ($header === null) {
+                    $header = $this->cleanHeader(array_keys($sourceRow));
+                    $stationCols = $this->extractStationColumns($header);
+                    $this->command->info('  '.count($stationCols).' station columns identified for this source row.');
+                }
+
+                $rowCount++;
+
+                try {
+                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols);
+                } catch (\Throwable $e) {
+                    $skippedSourceRows++;
+                    if ($skippedSourceRows <= 10) {
+                        $this->command->error("  row {$rowCount}: ".$e->getMessage());
+                    }
+
+                    continue;
+                }
+
+                foreach ($mainRows as $i => $mainRow) {
+                    $mainBatch[] = $mainRow;
+                    $metadataBatch[] = $metadataPayload + ['is_numeric_concentration' => $mainRow['is_numeric_concentration']];
+                }
+
+                if (count($mainBatch) >= self::BATCH_SIZE) {
+                    $this->flushBatch($mainBatch, $metadataBatch);
+                    $insertedMain += count($mainBatch);
+                    $mainBatch = [];
+                    $metadataBatch = [];
+                }
+
+                if ($rowCount % 200 === 0) {
+                    $now = microtime(true);
+                    $rate = round($rowCount / ($now - $startTime), 1);
+                    $this->command->info("  processed {$rowCount} source rows, {$insertedMain} main rows inserted ({$rate} src rows/s)");
+                    $lastReport = $now;
+                    gc_collect_cycles();
+                }
+            }
+
+            // Flush remainder
+            if (! empty($mainBatch)) {
+                $this->flushBatch($mainBatch, $metadataBatch);
+                $insertedMain += count($mainBatch);
+            }
+        } finally {
+            DB::statement('SET session_replication_role = default;');
+            DB::connection()->enableQueryLog();
+            if (class_exists(\Laravel\Telescope\Telescope::class)) {
+                \Laravel\Telescope\Telescope::startRecording();
+            }
+        }
+
+        $totalTime = round(microtime(true) - $startTime, 2);
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows.");
+        if ($skippedSourceRows > 0) {
+            $this->command->warn("Skipped {$skippedSourceRows} source rows due to errors.");
+        }
+
+        $this->validateSubstanceIds(self::FILE_ID);
+    }
+
+    /**
+     * Build the main + metadata rows for a single source row.
+     *
+     * Returns: [array<int, array> $mainRows, array $metadataPayloadCommonFields].
+     * Each main row's `is_numeric_concentration` is then attached to the corresponding
+     * metadata row in run() before insertion (so both share the same partition).
+     *
+     * @param  array<string, mixed>  $sourceRow
+     * @param  array<int, string>  $stationCols
+     * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
+     */
+    protected function buildRows(array $sourceRow, array $stationCols): array
+    {
+        $normanId = $this->cleanString($sourceRow['NORMAN_ID'] ?? null);
+        if ($normanId === null) {
+            return [[], []];
+        }
+
+        // Strip NS prefix, normalize, resolve to susdat_substances.id
+        $code = preg_replace('/^NS/i', '', $normanId) ?? '';
+        $substanceId = $this->resolveSubstanceId($code);
+
+        $ip = $this->cleanString($sourceRow['IP'] ?? null);
+        $ipMax = $this->cleanDouble($sourceRow['IP_max'] ?? null);
+        $basedOnHrms = $this->cleanBoolean($sourceRow['BasedonHRMSLibrary'] ?? null);
+        $units = $this->cleanString($sourceRow['Units'] ?? null);
+        $method = $this->cleanString($sourceRow['Method'] ?? null);
+
+        // Block E (metadata) values — same across all spawned main rows for this source row
+        $metadataPayload = ['method' => $method];
+        foreach (self::METADATA_COLUMN_MAP as $sourceCol => $destCol) {
+            $raw = $sourceRow[$sourceCol] ?? null;
+            if (in_array($destCol, self::METADATA_DOUBLE_COLUMNS, true)) {
+                $metadataPayload[$destCol] = $this->cleanDouble($raw);
+            } else {
+                $metadataPayload[$destCol] = $this->cleanString($raw);
+            }
+        }
+
+        $mainRows = [];
+        foreach ($stationCols as $colName) {
+            $raw = $sourceRow[$colName] ?? null;
+            if ($raw === null || $raw === '') {
+                continue;
+            }
+
+            $mapping = $this->stationMappingCache[$colName] ?? null;
+            if ($mapping === null) {
+                // Column not registered in mapping table — skip silently.
+                // (Mapping seeder should have inserted all station columns; if not,
+                // a non-empty cell here is genuinely lost. Logged in §3.6b QA.)
+                continue;
+            }
+
+            $concentration = $this->cleanDouble($raw);
+            $isNumeric = $concentration !== null;
+
+            $mainRows[] = [
+                'file_id' => self::FILE_ID,
+                'is_numeric_concentration' => $isNumeric,
+                'substance_id' => $substanceId,
+                'xlsx_station_mapping_id' => $mapping['mapping_id'],
+                'station_id' => $mapping['station_id'],
+                'concentration' => $concentration,
+                'ip' => $ip,
+                'ip_max' => $ipMax,
+                'based_on_hrms_library' => $basedOnHrms,
+                'units' => $units,
+            ];
+        }
+
+        return [$mainRows, $metadataPayload];
+    }
+
+    /**
+     * INSERT a batch of main rows with RETURNING id, then INSERT matching
+     * metadata rows using the captured ids. Both inserts run in a single
+     * transaction so partial failure leaves no orphan rows.
+     *
+     * @param  array<int, array<string, mixed>>  $mainBatch
+     * @param  array<int, array<string, mixed>>  $metadataBatch
+     */
+    protected function flushBatch(array $mainBatch, array $metadataBatch): void
+    {
+        if (count($mainBatch) !== count($metadataBatch)) {
+            throw new \LogicException('main/metadata batch length mismatch: '
+                .count($mainBatch).' vs '.count($metadataBatch));
+        }
+
+        DB::transaction(function () use ($mainBatch, $metadataBatch): void {
+            $mainCols = array_keys($mainBatch[0]);
+            $placeholders = '('.implode(', ', array_fill(0, count($mainCols), '?')).')';
+            $valuesSql = implode(', ', array_fill(0, count($mainBatch), $placeholders));
+            $colsSql = implode(', ', $mainCols);
+
+            $bindings = [];
+            foreach ($mainBatch as $row) {
+                foreach ($mainCols as $col) {
+                    $bindings[] = $row[$col];
+                }
+            }
+
+            $sql = "INSERT INTO empodat_suspect_main ({$colsSql}) VALUES {$valuesSql} "
+                .'RETURNING id, is_numeric_concentration';
+            $returned = DB::select($sql, $bindings);
+
+            if (count($returned) !== count($mainBatch)) {
+                throw new \RuntimeException('RETURNING count mismatch: '
+                    .count($returned).' vs expected '.count($mainBatch));
+            }
+
+            $metadataInsert = [];
+            foreach ($returned as $i => $r) {
+                $metadataInsert[] = $metadataBatch[$i] + [
+                    'id' => $r->id,
+                    'is_numeric_concentration' => $r->is_numeric_concentration,
+                ];
+            }
+            DB::table('empodat_suspect_metadata')->insert($metadataInsert);
+        });
+    }
+
+    /**
+     * Trim each header; strip UTF-8 BOM from the first column if present.
+     *
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * Extract station column names: everything after `Units`, before `mz score`.
+     *
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+            if ($name === '' || $name === null) {
+                continue;
+            }
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+
+    protected function cleanString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+
+        return ($cleaned === '' || $cleaned === 'NA') ? null : $cleaned;
+    }
+
+    protected function cleanDouble(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+
+        return is_numeric($cleaned) ? (float) $cleaned : null;
+    }
+
+    protected function cleanBoolean(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = strtoupper(trim((string) $value));
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+        if (in_array($cleaned, ['TRUE', '1', 'YES'], true)) {
+            return true;
+        }
+        if (in_array($cleaned, ['FALSE', '0', 'NO'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * BlackSea BIOTA pipeline — full end-to-end import in one command.
+ *
+ * Phases:
+ *   1. FileSeeder              — register file rows (10001–10011) in `files`
+ *   2. XlsxStationsMapping     — insert 11 station-column rows for file_id=10009
+ *   3. XlsxStationsMappingFill — resolve station_id via equality on short_sample_code
+ *   4. Substances              — populate empodat_suspect_substances for file_id=10009
+ *   5. Main+Metadata           — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *
+ * All phases are idempotent — safe to re-run.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaSeeder
+ */
+class EmpodatSuspectBlackSeaBiotaSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== BlackSea BIOTA pipeline (file_id=10009) ===');
+
+        $this->call([
+            EmpodatSuspectFileSeeder::class,
+            EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder::class,
+            EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectBlackSeaBiotaSubstancesSeeder::class,
+            EmpodatSuspectBlackSeaBiotaMainSeeder::class,
+        ]);
+
+        $this->command->info('=== BlackSea BIOTA pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSeeder.php
@@ -14,8 +14,10 @@ use Illuminate\Database\Seeder;
  *   1. FileSeeder              — register file rows (10001–10011) in `files`
  *   2. XlsxStationsMapping     — insert 11 station-column rows for file_id=10009
  *   3. XlsxStationsMappingFill — resolve station_id via equality on short_sample_code
- *   4. Substances              — populate empodat_suspect_substances for file_id=10009
- *   5. Main+Metadata           — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *   4. Main+Metadata           — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                AND populate empodat_suspect_substances in the same single pass
+ *                                (avoids reading the 19MB xlsx twice; saves ~130s vs. running
+ *                                EmpodatSuspectBlackSeaBiotaSubstancesSeeder separately)
  *
  * All phases are idempotent — safe to re-run.
  *
@@ -33,7 +35,6 @@ class EmpodatSuspectBlackSeaBiotaSeeder extends Seeder
             EmpodatSuspectFileSeeder::class,
             EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder::class,
             EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder::class,
-            EmpodatSuspectBlackSeaBiotaSubstancesSeeder::class,
             EmpodatSuspectBlackSeaBiotaMainSeeder::class,
         ]);
 

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSeeder.php
@@ -10,16 +10,16 @@ use Illuminate\Database\Seeder;
 /**
  * BlackSea BIOTA pipeline — full end-to-end import in one command.
  *
- * Phases:
- *   1. FileSeeder              — register file rows (10001–10011) in `files`
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10009 only):
+ *   1. BiotaFileSeeder         — register THIS file row in `files` (id=10009 only)
  *   2. XlsxStationsMapping     — insert 11 station-column rows for file_id=10009
  *   3. XlsxStationsMappingFill — resolve station_id via equality on short_sample_code
  *   4. Main+Metadata           — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
- *                                AND populate empodat_suspect_substances in the same single pass
- *                                (avoids reading the 19MB xlsx twice; saves ~130s vs. running
- *                                EmpodatSuspectBlackSeaBiotaSubstancesSeeder separately)
+ *                                + empodat_suspect_substances (all in one pass — avoids
+ *                                reading the 19MB xlsx twice)
  *
- * All phases are idempotent — safe to re-run.
+ * All phases are idempotent — safe to re-run. The pipeline only touches rows
+ * relevant to this source; other empodat_suspect file rows are untouched.
  *
  * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaSeeder
  */
@@ -32,7 +32,7 @@ class EmpodatSuspectBlackSeaBiotaSeeder extends Seeder
         $this->command->info('=== BlackSea BIOTA pipeline (file_id=10009) ===');
 
         $this->call([
-            EmpodatSuspectFileSeeder::class,
+            EmpodatSuspectBlackSeaBiotaFileSeeder::class,
             EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder::class,
             EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectBlackSeaBiotaMainSeeder::class,

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaSubstancesSeeder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Populate `empodat_suspect_substances` from BlackSea BIOTA.
+ *
+ * One row per unique (NORMAN_ID, Name) pair found in the source file,
+ * with file_id = 10009. Preserves NKUA's source spelling of `Name`, which can
+ * differ from `susdat_substances.name` — useful for triage when NORMAN_ID
+ * doesn't resolve.
+ *
+ * Idempotent: rows existing for (norman_id, file_id) are skipped.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (Block A, Column 2 `Name`)
+ */
+class EmpodatSuspectBlackSeaBiotaSubstancesSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10009;
+
+    protected const FILE_NAME = 'DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    public function run(): void
+    {
+        ini_set('memory_limit', '2G');
+        ini_set('max_execution_time', '7200');
+
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Streaming BlackSea BIOTA substances (file_id='.self::FILE_ID.')...');
+
+        $existing = DB::table('empodat_suspect_substances')
+            ->where('file_id', self::FILE_ID)
+            ->pluck('norman_id')
+            ->map(fn (?string $v): string => (string) $v)
+            ->flip()
+            ->all();
+
+        $reader = SimpleExcelReader::create($path);
+        $substances = [];
+        $rowCount = 0;
+        $skippedEmpty = 0;
+        $startTime = microtime(true);
+
+        DB::beginTransaction();
+
+        try {
+            foreach ($reader->getRows() as $row) {
+                $normanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $name = trim((string) ($row['Name'] ?? ''));
+
+                if ($normanId === '' || $name === '') {
+                    $skippedEmpty++;
+
+                    continue;
+                }
+
+                $key = $normanId.'|'.$name;
+                if (! isset($substances[$key]) && ! isset($existing[$normanId])) {
+                    $substances[$key] = [
+                        'norman_id' => $normanId,
+                        'name' => $name,
+                        'file_id' => self::FILE_ID,
+                    ];
+                }
+
+                $rowCount++;
+                if ($rowCount % 5000 === 0) {
+                    $this->command->info("  processed {$rowCount} rows, "
+                        .count($substances).' new substances queued...');
+                    gc_collect_cycles();
+                }
+            }
+
+            if (! empty($substances)) {
+                $chunks = array_chunk(array_values($substances), 500);
+                foreach ($chunks as $chunk) {
+                    DB::table('empodat_suspect_substances')->insert($chunk);
+                }
+            }
+
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
+
+        $totalTime = round(microtime(true) - $startTime, 2);
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} rows, inserted "
+            .count($substances).' new substances'
+            .($skippedEmpty > 0 ? " (skipped {$skippedEmpty} rows with empty NORMAN_ID or Name)" : '')
+            .'.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaSubstancesSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for BlackSea BIOTA mapping rows via direct lowercase
+ * equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10009 so different sources can't clobber each other.
+ *
+ * Handles non-uniqueness: short_sample_code is NOT unique in empodat_stations
+ * (e.g. Mf_BS1 matches IDs 153032 + 153057). We pick MIN(s.id) as the canonical
+ * resolved station_id and stash the full list in `ids` (STRING_AGG) with `count`.
+ *
+ * Excludes deprecated stations (`is_deprecated = true`).
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (column-by-column log, Block D)
+ */
+class EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10009;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for BlackSea BIOTA mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    /**
+     * Report any mapping rows for this file that still have NULL station_id.
+     * These are headers that didn't equality-match any empodat_stations.short_sample_code
+     * — flagged for manual mapping (see §3.6b in the plan doc).
+     */
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from BlackSea BIOTA into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/DCT_BIOTA_BlackSea2025_...xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary). Expected: 11 stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (column-by-column log)
+ *      Empodat-Suspect-new-source-onboarding.md §2  (single canonical location)
+ */
+class EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10009;
+
+    protected const FILE_NAME = 'DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    /** Structural marker: station columns begin AFTER this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker: HRMS metadata block (mz score, isotopicfit score, ...) begins HERE. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from BlackSea BIOTA (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * Trim each header; strip UTF-8 BOM from the first column if present.
+     *
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * Extract the station column names from the header row.
+     *
+     * Rules:
+     *   - Start collecting at the column AFTER `Units`.
+     *   - Stop collecting when we hit the metadata boundary `mz score`.
+     *   - Skip empty / null headers along the way.
+     *
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            // Hit the metadata block — stop.
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaXlsxStationsMappingSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the BlackSea SEDIMENT source file (id=10010) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the BlackSea SEDIMENT pipeline only.
+ * Called by EmpodatSuspectBlackSeaSedimentSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectBlackSeaSedimentFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10010],
+            [
+                'original_name' => 'DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'name' => 'BlackSea 2025 SEDIMENT Suspect Screening Results',
+                'description' => 'NKUA — BlackSea 2025 suspect screening, SEDIMENT matrix (dry weight, μg/kg dw). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSedimentFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentMainSeeder.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Database\Seeders\EmpodatSuspect\Traits\LoadsSubstanceCaches;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Stream BlackSea SEDIMENT xlsx → populate `empodat_suspect_main`,
+ * `empodat_suspect_metadata`, and `empodat_suspect_substances` in a single pass.
+ *
+ * Per source row:
+ *   - extract Block A/B/C fields (substance, IP, Units, …)
+ *   - extract Block E fields (13 HRMS metadata columns)
+ *   - accumulate unique (NORMAN_ID, Name) for end-of-run substances bulk insert
+ *   - find station columns (after `Units`, before `mz score`)
+ *   - for each non-NA station value: spawn one `empodat_suspect_main` row,
+ *     capture the returned id, spawn matching `empodat_suspect_metadata` row
+ *     with the same id + is_numeric_concentration.
+ *
+ * Single xlsx read (no separate substances pass) — see plan doc §3a.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a
+ */
+class EmpodatSuspectBlackSeaSedimentMainSeeder extends Seeder
+{
+    use LoadsSubstanceCaches;
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10010;
+
+    protected const FILE_NAME = 'DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    /** Source-column → empodat_suspect_metadata column name map (for Block E). */
+    protected const METADATA_COLUMN_MAP = [
+        'mz score' => 'mz_score',
+        'isotopicfit score' => 'isotopicfit_score',
+        'numoffragments score' => 'numoffragments_score',
+        'DDAMSMS score' => 'ddamsms_score',
+        'molecularfitfragments score' => 'molecularfitfragments_score',
+        'rti score' => 'rti_score',
+        'spectral similarity' => 'spectral_similarity',
+        'RT avg' => 'rt_avg',
+        'Fragments' => 'fragments',
+        'Based_on_similarity' => 'based_on_similarity',
+        'Based_on_compound' => 'based_on_compound',
+        'Identification_Proofs' => 'identification_proofs',
+        'NumFragments' => 'num_fragments',
+    ];
+
+    /** Columns stored as double precision in empodat_suspect_metadata. */
+    protected const METADATA_DOUBLE_COLUMNS = [
+        'mz_score', 'isotopicfit_score', 'numoffragments_score', 'ddamsms_score',
+        'molecularfitfragments_score', 'rti_score', 'spectral_similarity', 'rt_avg',
+        'num_fragments',
+    ];
+
+    protected const BATCH_SIZE = 500;
+
+    public function run(): void
+    {
+        ini_set('memory_limit', '4G');
+        ini_set('max_execution_time', '7200');
+
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Loading lookup caches...');
+        $this->loadLookupCaches();
+
+        if (class_exists(\Laravel\Telescope\Telescope::class)) {
+            \Laravel\Telescope\Telescope::stopRecording();
+        }
+        DB::connection()->disableQueryLog();
+        DB::statement('SET session_replication_role = replica;');
+
+        $this->command->info('Streaming BlackSea SEDIMENT → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
+            .self::FILE_ID.')...');
+
+        $existingSubstances = DB::table('empodat_suspect_substances')
+            ->where('file_id', self::FILE_ID)
+            ->pluck('norman_id')
+            ->map(fn (?string $v): string => (string) $v)
+            ->flip()
+            ->all();
+
+        $reader = SimpleExcelReader::create($path);
+
+        $header = null;
+        $stationCols = [];
+        $mainBatch = [];
+        $metadataBatch = [];
+        $substancesByKey = [];
+        $rowCount = 0;
+        $insertedMain = 0;
+        $insertedSubstances = 0;
+        $skippedSourceRows = 0;
+        $startTime = microtime(true);
+
+        try {
+            foreach ($reader->getRows() as $sourceRow) {
+                if ($header === null) {
+                    $header = $this->cleanHeader(array_keys($sourceRow));
+                    $stationCols = $this->extractStationColumns($header);
+                    $this->command->info('  '.count($stationCols).' station columns identified for this source row.');
+                }
+
+                $rowCount++;
+
+                try {
+                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols, $substancesByKey, $existingSubstances);
+                } catch (\Throwable $e) {
+                    $skippedSourceRows++;
+                    if ($skippedSourceRows <= 10) {
+                        $this->command->error("  row {$rowCount}: ".$e->getMessage());
+                    }
+
+                    continue;
+                }
+
+                foreach ($mainRows as $mainRow) {
+                    $mainBatch[] = $mainRow;
+                    $metadataBatch[] = $metadataPayload + ['is_numeric_concentration' => $mainRow['is_numeric_concentration']];
+                }
+
+                if (count($mainBatch) >= self::BATCH_SIZE) {
+                    $this->flushBatch($mainBatch, $metadataBatch);
+                    $insertedMain += count($mainBatch);
+                    $mainBatch = [];
+                    $metadataBatch = [];
+                }
+
+                if ($rowCount % 200 === 0) {
+                    $rate = round($rowCount / (microtime(true) - $startTime), 1);
+                    $this->command->info("  processed {$rowCount} source rows, {$insertedMain} main rows inserted ({$rate} src rows/s)");
+                    gc_collect_cycles();
+                }
+            }
+
+            if (! empty($mainBatch)) {
+                $this->flushBatch($mainBatch, $metadataBatch);
+                $insertedMain += count($mainBatch);
+            }
+
+            $insertedSubstances = $this->insertSubstances($substancesByKey);
+        } finally {
+            DB::statement('SET session_replication_role = default;');
+            DB::connection()->enableQueryLog();
+            if (class_exists(\Laravel\Telescope\Telescope::class)) {
+                \Laravel\Telescope\Telescope::startRecording();
+            }
+        }
+
+        $totalTime = round(microtime(true) - $startTime, 2);
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows, {$insertedSubstances} substances.");
+        if ($skippedSourceRows > 0) {
+            $this->command->warn("Skipped {$skippedSourceRows} source rows due to errors.");
+        }
+
+        $this->validateSubstanceIds(self::FILE_ID);
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRow
+     * @param  array<int, string>  $stationCols
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     * @param  array<string, int>  $existingSubstances
+     * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
+     */
+    protected function buildRows(array $sourceRow, array $stationCols, array &$substancesByKey, array $existingSubstances): array
+    {
+        $normanId = $this->cleanString($sourceRow['NORMAN_ID'] ?? null);
+        if ($normanId === null) {
+            return [[], []];
+        }
+
+        $name = $this->cleanString($sourceRow['Name'] ?? null);
+        if ($name !== null && ! isset($existingSubstances[$normanId])) {
+            $key = $normanId.'|'.$name;
+            $substancesByKey[$key] ??= [
+                'norman_id' => $normanId,
+                'name' => $name,
+                'file_id' => self::FILE_ID,
+            ];
+        }
+
+        $code = preg_replace('/^NS/i', '', $normanId) ?? '';
+        $substanceId = $this->resolveSubstanceId($code);
+
+        $ip = $this->cleanString($sourceRow['IP'] ?? null);
+        $ipMax = $this->cleanDouble($sourceRow['IP_max'] ?? null);
+        $basedOnHrms = $this->cleanBoolean($sourceRow['BasedonHRMSLibrary'] ?? null);
+        $units = $this->cleanString($sourceRow['Units'] ?? null);
+        $method = $this->cleanString($sourceRow['Method'] ?? null);
+
+        $metadataPayload = ['method' => $method];
+        foreach (self::METADATA_COLUMN_MAP as $sourceCol => $destCol) {
+            $raw = $sourceRow[$sourceCol] ?? null;
+            if (in_array($destCol, self::METADATA_DOUBLE_COLUMNS, true)) {
+                $metadataPayload[$destCol] = $this->cleanDouble($raw);
+            } else {
+                $metadataPayload[$destCol] = $this->cleanString($raw);
+            }
+        }
+
+        $mainRows = [];
+        foreach ($stationCols as $colName) {
+            $raw = $sourceRow[$colName] ?? null;
+            if ($raw === null || $raw === '') {
+                continue;
+            }
+
+            $mapping = $this->stationMappingCache[$colName] ?? null;
+            if ($mapping === null) {
+                continue;
+            }
+
+            $concentration = $this->cleanDouble($raw);
+            $isNumeric = $concentration !== null;
+
+            $mainRows[] = [
+                'file_id' => self::FILE_ID,
+                'is_numeric_concentration' => $isNumeric,
+                'substance_id' => $substanceId,
+                'xlsx_station_mapping_id' => $mapping['mapping_id'],
+                'station_id' => $mapping['station_id'],
+                'concentration' => $concentration,
+                'ip' => $ip,
+                'ip_max' => $ipMax,
+                'based_on_hrms_library' => $basedOnHrms,
+                'units' => $units,
+            ];
+        }
+
+        return [$mainRows, $metadataPayload];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $mainBatch
+     * @param  array<int, array<string, mixed>>  $metadataBatch
+     */
+    protected function flushBatch(array $mainBatch, array $metadataBatch): void
+    {
+        if (count($mainBatch) !== count($metadataBatch)) {
+            throw new \LogicException('main/metadata batch length mismatch: '
+                .count($mainBatch).' vs '.count($metadataBatch));
+        }
+
+        DB::transaction(function () use ($mainBatch, $metadataBatch): void {
+            $mainCols = array_keys($mainBatch[0]);
+            $placeholders = '('.implode(', ', array_fill(0, count($mainCols), '?')).')';
+            $valuesSql = implode(', ', array_fill(0, count($mainBatch), $placeholders));
+            $colsSql = implode(', ', $mainCols);
+
+            $bindings = [];
+            foreach ($mainBatch as $row) {
+                foreach ($mainCols as $col) {
+                    $bindings[] = $row[$col];
+                }
+            }
+
+            $sql = "INSERT INTO empodat_suspect_main ({$colsSql}) VALUES {$valuesSql} "
+                .'RETURNING id, is_numeric_concentration';
+            $returned = DB::select($sql, $bindings);
+
+            if (count($returned) !== count($mainBatch)) {
+                throw new \RuntimeException('RETURNING count mismatch: '
+                    .count($returned).' vs expected '.count($mainBatch));
+            }
+
+            $metadataInsert = [];
+            foreach ($returned as $i => $r) {
+                $metadataInsert[] = $metadataBatch[$i] + [
+                    'id' => $r->id,
+                    'is_numeric_concentration' => $r->is_numeric_concentration,
+                ];
+            }
+            DB::table('empodat_suspect_metadata')->insert($metadataInsert);
+        });
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     */
+    protected function insertSubstances(array $substancesByKey): int
+    {
+        if (empty($substancesByKey)) {
+            return 0;
+        }
+
+        $rows = array_values($substancesByKey);
+        $inserted = 0;
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('empodat_suspect_substances')->insert($chunk);
+            $inserted += count($chunk);
+        }
+
+        return $inserted;
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+            if ($name === '' || $name === null) {
+                continue;
+            }
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+
+    protected function cleanString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+
+        return ($cleaned === '' || $cleaned === 'NA') ? null : $cleaned;
+    }
+
+    protected function cleanDouble(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+
+        return is_numeric($cleaned) ? (float) $cleaned : null;
+    }
+
+    protected function cleanBoolean(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = strtoupper(trim((string) $value));
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+        if (in_array($cleaned, ['TRUE', '1', 'YES'], true)) {
+            return true;
+        }
+        if (in_array($cleaned, ['FALSE', '0', 'NO'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSedimentMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * BlackSea SEDIMENT pipeline — full end-to-end import in one command.
+ *
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10010 only):
+ *   1. SedimentFileSeeder      — register THIS file row in `files` (id=10010 only)
+ *   2. XlsxStationsMapping     — insert 10 station-column rows for file_id=10010
+ *   3. XlsxStationsMappingFill — resolve station_id via equality on short_sample_code
+ *   4. Main+Metadata           — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                + empodat_suspect_substances (all in one pass)
+ *
+ * All phases are idempotent — safe to re-run. ⚠️ Main+Metadata adds to existing
+ * data; truncate `empodat_suspect_main`/`empodat_suspect_metadata` for file_id=10010
+ * first if re-seeding from scratch.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSedimentSeeder
+ */
+class EmpodatSuspectBlackSeaSedimentSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== BlackSea SEDIMENT pipeline (file_id=10010) ===');
+
+        $this->call([
+            EmpodatSuspectBlackSeaSedimentFileSeeder::class,
+            EmpodatSuspectBlackSeaSedimentXlsxStationsMappingSeeder::class,
+            EmpodatSuspectBlackSeaSedimentXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectBlackSeaSedimentMainSeeder::class,
+        ]);
+
+        $this->command->info('=== BlackSea SEDIMENT pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for BlackSea SEDIMENT mapping rows via direct lowercase
+ * equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10010. Handles non-uniqueness via MIN(s.id) + STRING_AGG.
+ * Excludes deprecated stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (Block D)
+ */
+class EmpodatSuspectBlackSeaSedimentXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10010;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for BlackSea SEDIMENT mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSedimentXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentXlsxStationsMappingSeeder.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from BlackSea SEDIMENT into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/DCT_SEDIMENT_BlackSea2025_...xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary). Expected: 10 stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (column-by-column log)
+ */
+class EmpodatSuspectBlackSeaSedimentXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10010;
+
+    protected const FILE_NAME = 'DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    /** Structural marker: station columns begin AFTER this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker: HRMS metadata block (mz score, isotopicfit score, ...) begins HERE. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from BlackSea SEDIMENT (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSedimentXlsxStationsMappingSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the BlackSea Surface Water source file (id=10011) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the BlackSea SW pipeline only.
+ * Called by EmpodatSuspectBlackSeaSurfaceWaterSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectBlackSeaSurfaceWaterFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10011],
+            [
+                'original_name' => 'DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'name' => 'BlackSea 2025 Surface Water Suspect Screening Results',
+                'description' => 'NKUA — BlackSea 2025 suspect screening, surface water matrix (ng/L). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSurfaceWaterFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterMainSeeder.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Database\Seeders\EmpodatSuspect\Traits\LoadsSubstanceCaches;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Stream BlackSea Surface Water xlsx → populate `empodat_suspect_main`,
+ * `empodat_suspect_metadata`, and `empodat_suspect_substances` in a single pass.
+ *
+ * 20 station columns (most of the 3 BlackSea sources). Will be the first source
+ * to populate the currently-empty empodat_suspect_matrix_water_surface MV after
+ * a refresh.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a
+ */
+class EmpodatSuspectBlackSeaSurfaceWaterMainSeeder extends Seeder
+{
+    use LoadsSubstanceCaches;
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10011;
+
+    protected const FILE_NAME = 'DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    /** Source-column → empodat_suspect_metadata column name map (for Block E). */
+    protected const METADATA_COLUMN_MAP = [
+        'mz score' => 'mz_score',
+        'isotopicfit score' => 'isotopicfit_score',
+        'numoffragments score' => 'numoffragments_score',
+        'DDAMSMS score' => 'ddamsms_score',
+        'molecularfitfragments score' => 'molecularfitfragments_score',
+        'rti score' => 'rti_score',
+        'spectral similarity' => 'spectral_similarity',
+        'RT avg' => 'rt_avg',
+        'Fragments' => 'fragments',
+        'Based_on_similarity' => 'based_on_similarity',
+        'Based_on_compound' => 'based_on_compound',
+        'Identification_Proofs' => 'identification_proofs',
+        'NumFragments' => 'num_fragments',
+    ];
+
+    /** Columns stored as double precision in empodat_suspect_metadata. */
+    protected const METADATA_DOUBLE_COLUMNS = [
+        'mz_score', 'isotopicfit_score', 'numoffragments_score', 'ddamsms_score',
+        'molecularfitfragments_score', 'rti_score', 'spectral_similarity', 'rt_avg',
+        'num_fragments',
+    ];
+
+    protected const BATCH_SIZE = 500;
+
+    public function run(): void
+    {
+        ini_set('memory_limit', '4G');
+        ini_set('max_execution_time', '7200');
+
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Loading lookup caches...');
+        $this->loadLookupCaches();
+
+        if (class_exists(\Laravel\Telescope\Telescope::class)) {
+            \Laravel\Telescope\Telescope::stopRecording();
+        }
+        DB::connection()->disableQueryLog();
+        DB::statement('SET session_replication_role = replica;');
+
+        $this->command->info('Streaming BlackSea Surface Water → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
+            .self::FILE_ID.')...');
+
+        $existingSubstances = DB::table('empodat_suspect_substances')
+            ->where('file_id', self::FILE_ID)
+            ->pluck('norman_id')
+            ->map(fn (?string $v): string => (string) $v)
+            ->flip()
+            ->all();
+
+        $reader = SimpleExcelReader::create($path);
+
+        $header = null;
+        $stationCols = [];
+        $mainBatch = [];
+        $metadataBatch = [];
+        $substancesByKey = [];
+        $rowCount = 0;
+        $insertedMain = 0;
+        $insertedSubstances = 0;
+        $skippedSourceRows = 0;
+        $startTime = microtime(true);
+
+        try {
+            foreach ($reader->getRows() as $sourceRow) {
+                if ($header === null) {
+                    $header = $this->cleanHeader(array_keys($sourceRow));
+                    $stationCols = $this->extractStationColumns($header);
+                    $this->command->info('  '.count($stationCols).' station columns identified for this source row.');
+                }
+
+                $rowCount++;
+
+                try {
+                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols, $substancesByKey, $existingSubstances);
+                } catch (\Throwable $e) {
+                    $skippedSourceRows++;
+                    if ($skippedSourceRows <= 10) {
+                        $this->command->error("  row {$rowCount}: ".$e->getMessage());
+                    }
+
+                    continue;
+                }
+
+                foreach ($mainRows as $mainRow) {
+                    $mainBatch[] = $mainRow;
+                    $metadataBatch[] = $metadataPayload + ['is_numeric_concentration' => $mainRow['is_numeric_concentration']];
+                }
+
+                if (count($mainBatch) >= self::BATCH_SIZE) {
+                    $this->flushBatch($mainBatch, $metadataBatch);
+                    $insertedMain += count($mainBatch);
+                    $mainBatch = [];
+                    $metadataBatch = [];
+                }
+
+                if ($rowCount % 200 === 0) {
+                    $rate = round($rowCount / (microtime(true) - $startTime), 1);
+                    $this->command->info("  processed {$rowCount} source rows, {$insertedMain} main rows inserted ({$rate} src rows/s)");
+                    gc_collect_cycles();
+                }
+            }
+
+            if (! empty($mainBatch)) {
+                $this->flushBatch($mainBatch, $metadataBatch);
+                $insertedMain += count($mainBatch);
+            }
+
+            $insertedSubstances = $this->insertSubstances($substancesByKey);
+        } finally {
+            DB::statement('SET session_replication_role = default;');
+            DB::connection()->enableQueryLog();
+            if (class_exists(\Laravel\Telescope\Telescope::class)) {
+                \Laravel\Telescope\Telescope::startRecording();
+            }
+        }
+
+        $totalTime = round(microtime(true) - $startTime, 2);
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows, {$insertedSubstances} substances.");
+        if ($skippedSourceRows > 0) {
+            $this->command->warn("Skipped {$skippedSourceRows} source rows due to errors.");
+        }
+
+        $this->validateSubstanceIds(self::FILE_ID);
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRow
+     * @param  array<int, string>  $stationCols
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     * @param  array<string, int>  $existingSubstances
+     * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
+     */
+    protected function buildRows(array $sourceRow, array $stationCols, array &$substancesByKey, array $existingSubstances): array
+    {
+        $normanId = $this->cleanString($sourceRow['NORMAN_ID'] ?? null);
+        if ($normanId === null) {
+            return [[], []];
+        }
+
+        $name = $this->cleanString($sourceRow['Name'] ?? null);
+        if ($name !== null && ! isset($existingSubstances[$normanId])) {
+            $key = $normanId.'|'.$name;
+            $substancesByKey[$key] ??= [
+                'norman_id' => $normanId,
+                'name' => $name,
+                'file_id' => self::FILE_ID,
+            ];
+        }
+
+        $code = preg_replace('/^NS/i', '', $normanId) ?? '';
+        $substanceId = $this->resolveSubstanceId($code);
+
+        $ip = $this->cleanString($sourceRow['IP'] ?? null);
+        $ipMax = $this->cleanDouble($sourceRow['IP_max'] ?? null);
+        $basedOnHrms = $this->cleanBoolean($sourceRow['BasedonHRMSLibrary'] ?? null);
+        $units = $this->cleanString($sourceRow['Units'] ?? null);
+        $method = $this->cleanString($sourceRow['Method'] ?? null);
+
+        $metadataPayload = ['method' => $method];
+        foreach (self::METADATA_COLUMN_MAP as $sourceCol => $destCol) {
+            $raw = $sourceRow[$sourceCol] ?? null;
+            if (in_array($destCol, self::METADATA_DOUBLE_COLUMNS, true)) {
+                $metadataPayload[$destCol] = $this->cleanDouble($raw);
+            } else {
+                $metadataPayload[$destCol] = $this->cleanString($raw);
+            }
+        }
+
+        $mainRows = [];
+        foreach ($stationCols as $colName) {
+            $raw = $sourceRow[$colName] ?? null;
+            if ($raw === null || $raw === '') {
+                continue;
+            }
+
+            $mapping = $this->stationMappingCache[$colName] ?? null;
+            if ($mapping === null) {
+                continue;
+            }
+
+            $concentration = $this->cleanDouble($raw);
+            $isNumeric = $concentration !== null;
+
+            $mainRows[] = [
+                'file_id' => self::FILE_ID,
+                'is_numeric_concentration' => $isNumeric,
+                'substance_id' => $substanceId,
+                'xlsx_station_mapping_id' => $mapping['mapping_id'],
+                'station_id' => $mapping['station_id'],
+                'concentration' => $concentration,
+                'ip' => $ip,
+                'ip_max' => $ipMax,
+                'based_on_hrms_library' => $basedOnHrms,
+                'units' => $units,
+            ];
+        }
+
+        return [$mainRows, $metadataPayload];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $mainBatch
+     * @param  array<int, array<string, mixed>>  $metadataBatch
+     */
+    protected function flushBatch(array $mainBatch, array $metadataBatch): void
+    {
+        if (count($mainBatch) !== count($metadataBatch)) {
+            throw new \LogicException('main/metadata batch length mismatch: '
+                .count($mainBatch).' vs '.count($metadataBatch));
+        }
+
+        DB::transaction(function () use ($mainBatch, $metadataBatch): void {
+            $mainCols = array_keys($mainBatch[0]);
+            $placeholders = '('.implode(', ', array_fill(0, count($mainCols), '?')).')';
+            $valuesSql = implode(', ', array_fill(0, count($mainBatch), $placeholders));
+            $colsSql = implode(', ', $mainCols);
+
+            $bindings = [];
+            foreach ($mainBatch as $row) {
+                foreach ($mainCols as $col) {
+                    $bindings[] = $row[$col];
+                }
+            }
+
+            $sql = "INSERT INTO empodat_suspect_main ({$colsSql}) VALUES {$valuesSql} "
+                .'RETURNING id, is_numeric_concentration';
+            $returned = DB::select($sql, $bindings);
+
+            if (count($returned) !== count($mainBatch)) {
+                throw new \RuntimeException('RETURNING count mismatch: '
+                    .count($returned).' vs expected '.count($mainBatch));
+            }
+
+            $metadataInsert = [];
+            foreach ($returned as $i => $r) {
+                $metadataInsert[] = $metadataBatch[$i] + [
+                    'id' => $r->id,
+                    'is_numeric_concentration' => $r->is_numeric_concentration,
+                ];
+            }
+            DB::table('empodat_suspect_metadata')->insert($metadataInsert);
+        });
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     */
+    protected function insertSubstances(array $substancesByKey): int
+    {
+        if (empty($substancesByKey)) {
+            return 0;
+        }
+
+        $rows = array_values($substancesByKey);
+        $inserted = 0;
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('empodat_suspect_substances')->insert($chunk);
+            $inserted += count($chunk);
+        }
+
+        return $inserted;
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+            if ($name === '' || $name === null) {
+                continue;
+            }
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+
+    protected function cleanString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+
+        return ($cleaned === '' || $cleaned === 'NA') ? null : $cleaned;
+    }
+
+    protected function cleanDouble(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+
+        return is_numeric($cleaned) ? (float) $cleaned : null;
+    }
+
+    protected function cleanBoolean(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = strtoupper(trim((string) $value));
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+        if (in_array($cleaned, ['TRUE', '1', 'YES'], true)) {
+            return true;
+        }
+        if (in_array($cleaned, ['FALSE', '0', 'NO'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSurfaceWaterMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterSeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * BlackSea Surface Water pipeline — full end-to-end import in one command.
+ *
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10011 only):
+ *   1. SurfaceWaterFileSeeder  — register THIS file row in `files` (id=10011 only)
+ *   2. XlsxStationsMapping     — insert 20 station-column rows for file_id=10011
+ *   3. XlsxStationsMappingFill — resolve station_id via equality on short_sample_code
+ *   4. Main+Metadata           — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                + empodat_suspect_substances (all in one pass)
+ *
+ * Notable: this is the first BlackSea source with a water-matrix substance set,
+ * so after seeding + MV refresh, empodat_suspect_matrix_water_surface (currently
+ * 0 rows) will populate.
+ *
+ * All phases are idempotent — safe to re-run. ⚠️ Main+Metadata adds to existing
+ * data; truncate `empodat_suspect_main`/`empodat_suspect_metadata` for file_id=10011
+ * first if re-seeding from scratch.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSurfaceWaterSeeder
+ */
+class EmpodatSuspectBlackSeaSurfaceWaterSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== BlackSea Surface Water pipeline (file_id=10011) ===');
+
+        $this->call([
+            EmpodatSuspectBlackSeaSurfaceWaterFileSeeder::class,
+            EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingSeeder::class,
+            EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectBlackSeaSurfaceWaterMainSeeder::class,
+        ]);
+
+        $this->command->info('=== BlackSea Surface Water pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for BlackSea Surface Water mapping rows via direct
+ * lowercase equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10011. Handles non-uniqueness via MIN(s.id) + STRING_AGG.
+ * Excludes deprecated stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (Block D)
+ */
+class EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10011;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for BlackSea Surface Water mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingSeeder.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from BlackSea Surface Water into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/DCT_SW_BlackSea2025_...xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary). Expected: 20 stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §3a (column-by-column log)
+ */
+class EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10011;
+
+    protected const FILE_NAME = 'DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx';
+
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from BlackSea Surface Water (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSurfaceWaterXlsxStationsMappingSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectFileSeeder.php
@@ -14,12 +14,15 @@ class EmpodatSuspectFileSeeder extends Seeder
     /**
      * Run the database seeds.
      *
-     * This seeder creates/updates all File records for Empodat Suspect data sources.
-     * Must be run before any of the main data seeders.
+     * Creates/updates File records for the 8 legacy Empodat Suspect data sources.
+     * BlackSea (10009–10011), TerraChem (10012–10015), and any new sources have
+     * their own dedicated per-source FileSeeders — e.g.
+     * EmpodatSuspectBlackSeaSedimentFileSeeder. Each pipeline orchestrator calls
+     * only the FileSeeder relevant to its source.
      */
     public function run(): void
     {
-        $this->command->info('Creating/updating File records for Empodat Suspect data sources...');
+        $this->command->info('Creating/updating File records for Empodat Suspect legacy sources...');
 
         $files = [
             [
@@ -91,33 +94,6 @@ class EmpodatSuspectFileSeeder extends Seeder
                 'name' => 'UBA-HELCOM Suspect Screening Results',
                 'description' => 'UBA-HELCOM suspect screening results - BIOTA data',
                 'file_path' => 'empodat_suspect/OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.xlsx',
-                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                'database_entity_id' => 18,
-            ],
-            [
-                'id' => 10009,
-                'original_name' => 'DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
-                'name' => 'BlackSea 2025 BIOTA Suspect Screening Results',
-                'description' => 'NKUA — BlackSea 2025 suspect screening, BIOTA matrix (wet weight, μg/kg ww). Includes HRMS identification metadata (mz score, RTI, fragments, etc.) stored in empodat_suspect_metadata.',
-                'file_path' => 'empodat_suspect/DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
-                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                'database_entity_id' => 18,
-            ],
-            [
-                'id' => 10010,
-                'original_name' => 'DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
-                'name' => 'BlackSea 2025 SEDIMENT Suspect Screening Results',
-                'description' => 'NKUA — BlackSea 2025 suspect screening, SEDIMENT matrix (dry weight, μg/kg dw). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
-                'file_path' => 'empodat_suspect/DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
-                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                'database_entity_id' => 18,
-            ],
-            [
-                'id' => 10011,
-                'original_name' => 'DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
-                'name' => 'BlackSea 2025 Surface Water Suspect Screening Results',
-                'description' => 'NKUA — BlackSea 2025 suspect screening, surface water matrix (ng/L). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
-                'file_path' => 'empodat_suspect/DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
                 'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                 'database_entity_id' => 18,
             ],

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectFileSeeder.php
@@ -94,6 +94,33 @@ class EmpodatSuspectFileSeeder extends Seeder
                 'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                 'database_entity_id' => 18,
             ],
+            [
+                'id' => 10009,
+                'original_name' => 'DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'name' => 'BlackSea 2025 BIOTA Suspect Screening Results',
+                'description' => 'NKUA — BlackSea 2025 suspect screening, BIOTA matrix (wet weight, μg/kg ww). Includes HRMS identification metadata (mz score, RTI, fragments, etc.) stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+            ],
+            [
+                'id' => 10010,
+                'original_name' => 'DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'name' => 'BlackSea 2025 SEDIMENT Suspect Screening Results',
+                'description' => 'NKUA — BlackSea 2025 suspect screening, SEDIMENT matrix (dry weight, μg/kg dw). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+            ],
+            [
+                'id' => 10011,
+                'original_name' => 'DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'name' => 'BlackSea 2025 Surface Water Suspect Screening Results',
+                'description' => 'NKUA — BlackSea 2025 suspect screening, surface water matrix (ng/L). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+            ],
         ];
 
         $now = Carbon::now();


### PR DESCRIPTION
## Summary

- Imports the 3 BlackSea 2025 suspect-screening data files from NKUA (BIOTA, SEDIMENT, surface water) — file IDs 10009, 10010, 10011.
- Introduces a new partitioned side-table `empodat_suspect_metadata` (1:1 with `empodat_suspect_main`) to hold the 13 HRMS identification-metadata columns that NKUA's DCT template carries beyond the legacy schema (mz score, RTI score, RT avg, fragments, Identification_Proofs, etc.).
- Establishes a per-source FileSeeder pattern for new sources so each pipeline only touches its own `files` row (no more re-touching all 11 legacy entries on every run).
- Fixes a CONCURRENT-refresh blocker on the `empodat_suspect_station_filters` materialised view (expression-based unique index → plain-column unique index).

## What's in the commits

1. `86a4a36` — BlackSea BIOTA pipeline (5-step) + `empodat_suspect_metadata` migration (partitioned LIST on `is_numeric_concentration`, mirrors main table layout)
2. `9c4d922` — Optimise BIOTA: merge substances insert into the main streaming pass so the 19MB xlsx is read once instead of twice (~60% faster)
3. `f8b84b6` — SEDIMENT pipeline (file_id 10010, 10 stations) + per-source FileSeeders (Biota/Sediment/SurfaceWater) so orchestrators only touch their own file row
4. `6521756` — Fix `idx_essf_unique_combo` to enable `REFRESH MATERIALIZED VIEW CONCURRENTLY` (PG rejects expression indexes with COALESCE wrappers)
5. `2aa2403` — Surface Water pipeline (file_id 10011, 20 stations) — will populate the currently-empty `empodat_suspect_matrix_water_surface` MV

## Migrations (2 new)

- `2026_05_21_120000_create_empodat_suspect_metadata_table.php`
- `2026_05_21_140000_fix_empodat_suspect_station_filters_unique_index_for_concurrent_refresh.php`

Run via the Migrate Production DB workflow (per CONTRIBUTING §7). First run with `pretend: true`, then `pretend: false`.

## Source files (production rsync)

Three xlsx files in `storage/app/public/empodat_suspect/` locally must be rsynced to `/opt/projects/norman_database_system/shared/storage/app/public/empodat_suspect/` on prod:
- `DCT_BIOTA_BlackSea2025_SS_NKUA_15042026_v1.xlsx` (19 MB)
- `DCT_SEDIMENT_BlackSea2025_SS_NKUA_15042026_v1.xlsx` (19 MB)
- `DCT_SW_BlackSea2025_SS_NKUA_15042026_v1.xlsx` (22 MB)

Same canonical location for both seeder + `FileController::download()` — no two-copy duplication (departing from the legacy 8's pattern; legacy 8 untouched).

## How to run each pipeline (one command per source)

```bash
php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaBiotaSeeder
php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSedimentSeeder
php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectBlackSeaSurfaceWaterSeeder
```

Each orchestrator runs its 4 phases (per-source FileSeeder → Mapping → Fill → Main+Metadata+Substances merged). Idempotent for FileSeeder/Mapping/Fill; Main re-inserts on re-run (truncate file_id rows first if re-seeding from scratch).

## Verified locally

- BIOTA: 95738 source rows → 1053111 main+metadata rows, 11/11 stations resolved, substance ID validation passed
- SEDIMENT: 957368 main+metadata rows, 10/10 stations resolved
- SW: pending user verification (was running when PR was opened)
- All 3 metadata tables 1:1 paired by `(id, is_numeric_concentration)`

## Test plan

- [ ] CI green (composer install + npm build)
- [ ] Migrations dry-run with `pretend: true` on production
- [ ] Migrations applied with `pretend: false`
- [ ] Rsync 3 xlsx files to `shared/storage/app/public/empodat_suspect/`
- [ ] Run the 3 pipelines on production (per command above)
- [ ] Run `pg_table_*` scripts if seeding locally + transferring (per `Empodat-Suspect-setup.md`)
- [ ] `php artisan empodat-suspect:refresh-filters` → check `--stats` (the CONCURRENT-refresh fix unblocks this)
- [ ] `php artisan empodat-suspect:refresh-prioritisation`
- [ ] `php artisan empodat-suspect:refresh-matrix-metadata` → verify `empodat_suspect_matrix_water_surface` populates (currently 0 rows)
- [ ] Smoke: download buttons work for files 10009/10010/10011 via FileController
- [ ] `/empodat_suspect/search/filter` shows new BlackSea data

## Out of scope

- TerraChem (4 sources, file IDs 10012–10015) — separate PR, planned to use the generic-importer framework once the BlackSea pattern is validated
- Backporting legacy 8 sources to the single-canonical-location convention — separate cleanup