### PR TITLE
Feature/hazards module v2

### DIFF
--- a/app/Http/Controllers/Factsheet/FactsheetController.php
+++ b/app/Http/Controllers/Factsheet/FactsheetController.php
@@ -68,11 +68,6 @@ class FactsheetController extends Controller
 
         // Process each entity to prepare presentation data
         foreach ($factsheetEntities as $entity) {
-            if ($entity->name === 'PBT/vPvB & PMT/vPvM (NORMAN)') {
-                $entity->processed_data = $this->getHazardsPbtPmtData($substance);
-                continue;
-            }
-
             if (isset($entity->data['method_of_presentation'])) {
                 if ($entity->data['method_of_presentation'] === 'database_table') {
                     // CASE 1: Database table presentation
@@ -237,13 +232,7 @@ class FactsheetController extends Controller
                             'summary' => $methodData['summary'] ?? [],
                         ];
                     } elseif ($methodData['type'] === 'hazards_pbt_table') {
-                        return [
-                            'type' => 'hazards_pbt_table',
-                            'rows' => $methodData['rows'] ?? [],
-                            'source_label' => $methodData['source_label'] ?? null,
-                            'updated_at' => $methodData['updated_at'] ?? null,
-                            'legend' => $methodData['legend'] ?? [],
-                        ];
+                        return $methodData;
                     }
                 }
 
@@ -733,6 +722,5 @@ class FactsheetController extends Controller
         }
     }
 }
-
 
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,8 +16,6 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
-        // php artisan db:seed --class=Database\Seeders\Hazards\HazardsJanusSeeder
-        // php artisan db:seed --class=Database\Seeders\Hazards\HazardsPikmeSeeder
 
         // User::factory()->create([
         //     'name' => 'Test User',

--- a/database/seeders/FactsheetEntitySeeder.php
+++ b/database/seeders/FactsheetEntitySeeder.php
@@ -67,7 +67,7 @@ class FactsheetEntitySeeder extends Seeder
             [
                 'name' => 'PBT/vPvB & PMT/vPvM (NORMAN)',
                 'sort_order' => 8,
-                'data' => json_encode(['method_of_presentation' => 'controller_method', 'method' => 'getHazardsPbtPmtData']),
+                'data' => json_encode(['method_of_presentation' => 'banner', 'color' => 'green', 'text' => 'This module is currently under development.']),
                 'created_at' => $now,
                 'updated_at' => $now,
             ],

--- a/database/seeders/Hazards/HazardsJanusSeeder.php
+++ b/database/seeders/Hazards/HazardsJanusSeeder.php
@@ -24,6 +24,7 @@ class HazardsJanusSeeder extends Seeder
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");
+
             return;
         }
 
@@ -32,7 +33,7 @@ class HazardsJanusSeeder extends Seeder
         Schema::disableForeignKeyConstraints();
 
         try {
-            DB::table($targetTable)->delete();
+            DB::table($targetTable)->truncate();
 
             $reader = SimpleExcelReader::create($path)
                 ->useDelimiter(',')
@@ -103,7 +104,7 @@ class HazardsJanusSeeder extends Seeder
                     $chunkElapsedTime = round($chunkEndTime - $chunkStartTime, 2);
                     $totalElapsedTime = round($chunkEndTime - $startTime, 2);
 
-                    $this->command->info("Processed chunk ".($key + 1)." with ".count($records)." JANUS records. Chunk time: {$chunkElapsedTime}s, Total elapsed: {$totalElapsedTime}s");
+                    $this->command->info('Processed chunk '.($key + 1).' with '.count($records)." JANUS records. Chunk time: {$chunkElapsedTime}s, Total elapsed: {$totalElapsedTime}s");
                 });
         } finally {
             Schema::enableForeignKeyConstraints();

--- a/database/seeders/Hazards/HazardsMainSeeder.php
+++ b/database/seeders/Hazards/HazardsMainSeeder.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Database\Seeders\Hazards;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class HazardsMainSeeder extends Seeder
+{
+    /**
+     * Run the Hazards module seeds.
+     */
+    public function run(): void
+    {
+        $this->upsertDatabaseEntity();
+        $this->upsertFactsheetEntities();
+
+        $this->call([
+            HazardsJanusSeeder::class,
+            HazardsPikmeSeeder::class,
+        ]);
+    }
+
+    private function upsertDatabaseEntity(): void
+    {
+        $now = now();
+        $row = DB::table('database_entities')
+            ->where('code', 'hazards')
+            ->first();
+        $values = [
+            'name' => 'Hazards and Properties',
+            'description' => 'CompTox hazards and properties placeholder entity',
+            'image_path' => 'fas fa-triangle-exclamation',
+            'code' => 'hazards',
+            'dashboard_route_name' => 'hazardshome.index',
+            'last_update' => null,
+            'number_of_records' => 0,
+            'parent_id' => null,
+            'show_in_dashboard' => true,
+            'has_templates' => false,
+            'is_public' => true,
+        ];
+
+        if (! $row) {
+            DB::table('database_entities')->insert($values + [
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            return;
+        }
+
+        if ($this->rowMatches($row, $values)) {
+            return;
+        }
+
+        DB::table('database_entities')
+            ->where('id', $row->id)
+            ->update($values + ['updated_at' => $now]);
+    }
+
+    private function upsertFactsheetEntities(): void
+    {
+        $now = now();
+        $row = DB::table('factsheet_entities')
+            ->where('name', 'PBT/vPvB & PMT/vPvM (NORMAN)')
+            ->first();
+        $values = [
+            'name' => 'PBT/vPvB & PMT/vPvM (NORMAN)',
+            'sort_order' => 8,
+            'data' => json_encode([
+                'method_of_presentation' => 'controller_method',
+                'method' => 'getHazardsPbtPmtData',
+            ]),
+        ];
+
+        if (! $row) {
+            DB::table('factsheet_entities')->insert($values + [
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            return;
+        }
+
+        if ($this->rowMatches($row, $values)) {
+            return;
+        }
+
+        DB::table('factsheet_entities')
+            ->where('id', $row->id)
+            ->update($values + ['updated_at' => $now]);
+    }
+
+    private function rowMatches(object $row, array $values): bool
+    {
+        foreach ($values as $column => $value) {
+            if ($this->normalizeValue($row->{$column} ?? null) !== $this->normalizeValue($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function normalizeValue(mixed $value): mixed
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+}

--- a/database/seeders/Hazards/HazardsPikmeSeeder.php
+++ b/database/seeders/Hazards/HazardsPikmeSeeder.php
@@ -24,6 +24,7 @@ class HazardsPikmeSeeder extends Seeder
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");
+
             return;
         }
 
@@ -32,7 +33,7 @@ class HazardsPikmeSeeder extends Seeder
         Schema::disableForeignKeyConstraints();
 
         try {
-            DB::table($targetTable)->delete();
+            DB::table($targetTable)->truncate();
 
             $reader = SimpleExcelReader::create($path)
                 ->useDelimiter(',')
@@ -89,7 +90,7 @@ class HazardsPikmeSeeder extends Seeder
                     $chunkElapsedTime = round($chunkEndTime - $chunkStartTime, 2);
                     $totalElapsedTime = round($chunkEndTime - $startTime, 2);
 
-                    $this->command->info("Processed chunk ".($key + 1)." with ".count($records)." PIKME records. Chunk time: {$chunkElapsedTime}s, Total elapsed: {$totalElapsedTime}s");
+                    $this->command->info('Processed chunk '.($key + 1).' with '.count($records)." PIKME records. Chunk time: {$chunkElapsedTime}s, Total elapsed: {$totalElapsedTime}s");
                 });
         } finally {
             Schema::enableForeignKeyConstraints();

--- a/database/seeders/seeds/database_entities.csv
+++ b/database/seeders/seeds/database_entities.csv
@@ -1,4 +1,4 @@
-﻿id,name,description,image_path,code,dashboard_route_name,last_update,number_of_records,created_at,updated_at,parent_id,show_in_dashboard,has_templates,is_public
+id,name,description,image_path,code,dashboard_route_name,last_update,number_of_records,created_at,updated_at,parent_id,show_in_dashboard,has_templates,is_public
 5,Antibiotic Resistant Bacteria/Genes,A database of ARBs/ARGs in environmental matrices,fas fa-bacterium,arbg,arbghome.index,,3741,2024-12-01 17:41:28,2025-05-06 18:45:05,,true,true,true
 8,Indoor Environment,A database of data in indoor environment matrices,fa fa-home,indoor,indoorhome.index,,177600,2024-12-01 17:41:28,2025-04-26 10:59:26,,true,true,true
 9,Passive Sampling,A database of data obtained with passive samplers,fa fa-cogs,passive,passivehome.index,,4213,2024-12-01 17:41:28,2025-04-26 14:17:55,,true,true,true
@@ -17,5 +17,3 @@
 11,Prioritisation,Results of prioritisation of NORMAN substances using the NORMAN Prioritisation Framework,fa-regular fa-chart-bar,prioritisation,prioritisationhome.index,,3920,2024-12-01 17:41:28,2025-04-30 18:08:02,,true,false,true
 2,Chemical Occurrence Data,A database of geo-referenced monitoring data on emerging substances,fa fa-share-alt,empodat,codhome.index,,97240351,2024-12-01 17:41:28,2025-09-30 11:08:03,,true,true,true
 18,Empodat Suspect,Empodat Suspect screening results module,fas fa-vial,empodat_suspect,empodat_suspect.home.index,,0,2025-10-22 16:53:50,2025-10-22 16:53:50,,true,false,false
-19,Hazards and Properties,CompTox hazards and properties placeholder entity,fas fa-triangle-exclamation,hazards,hazardshome.index,,0,2026-03-02 09:00:00,2026-03-02 09:00:00,,true,false,true
-


### PR DESCRIPTION
Reworked Hazards module seeding per review.

Changes:
- Added isolated Database\Seeders\Hazards\HazardsMainSeeder.
- HazardsMainSeeder upserts required shared rows into database_entities and factsheet_entities.
- HazardsMainSeeder populates the hazards_janus and hazards_pikme tables.
- Removed Hazards changes from DatabaseSeeder, FactsheetEntitySeeder, and shared seed CSVs.
- Hazards is not auto-wired into DatabaseSeeder and must be run explicitly.
- Hazards factsheet integration now follows factsheet_entities configuration instead of a hardcoded controller shortcut.

Run with:
php artisan db:seed --class="Database\Seeders\Hazards\HazardsMainSeeder"