### PR TITLE
Fix empodat_suspect sample-code detail views (array_sum on array of arrays)

### DIFF
--- a/resources/views/empodat_suspect/statistics/records_by_sample_code.blade.php
+++ b/resources/views/empodat_suspect/statistics/records_by_sample_code.blade.php
@@ -32,13 +32,18 @@
           <div class="text-sm text-gray-600">Total Sample Codes</div>
           <div class="text-2xl font-bold text-gray-900">{{ number_format($totalSampleCodes, 0, '.', ' ') }}</div>
         </div>
+        @php
+          // Data shape per sample_code is ['total' => int, 'numeric' => int, 'non_numeric' => int].
+          // Sum the 'total' (or the bare int for legacy stats predating the partitioning split).
+          $totalRecords = collect($data)->sum(fn ($v) => is_array($v) ? ($v['total'] ?? 0) : $v);
+        @endphp
         <div>
           <div class="text-sm text-gray-600">Total Records (sum)</div>
-          <div class="text-2xl font-bold text-gray-900">{{ number_format(array_sum($data), 0, '.', ' ') }}</div>
+          <div class="text-2xl font-bold text-gray-900">{{ number_format($totalRecords, 0, '.', ' ') }}</div>
         </div>
         <div>
           <div class="text-sm text-gray-600">Average Records per Code</div>
-          <div class="text-2xl font-bold text-gray-900">{{ number_format(array_sum($data) / max($totalSampleCodes, 1), 1, '.', ' ') }}</div>
+          <div class="text-2xl font-bold text-gray-900">{{ number_format($totalRecords / max($totalSampleCodes, 1), 1, '.', ' ') }}</div>
         </div>
       </div>
     </div>
@@ -58,13 +63,23 @@
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
-            @foreach(collect($data)->sortByDesc(function($count) { return $count; }) as $sampleCode => $count)
+            @foreach(collect($data)->sortByDesc(fn ($v) => is_array($v) ? ($v['total'] ?? 0) : $v) as $sampleCode => $info)
+              @php
+                $total       = is_array($info) ? ($info['total'] ?? 0)       : $info;
+                $numeric     = is_array($info) ? ($info['numeric'] ?? 0)     : 0;
+                $nonNumeric  = is_array($info) ? ($info['non_numeric'] ?? 0) : 0;
+              @endphp
               <tr>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                   {{ $sampleCode }}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  {{ number_format($count, 0, '.', ' ') }}
+                  {{ number_format($total, 0, '.', ' ') }}
+                  @if(is_array($info))
+                    <span class="text-xs text-gray-400 ml-2">
+                      ({{ number_format($numeric, 0, '.', ' ') }} numeric / {{ number_format($nonNumeric, 0, '.', ' ') }} N/A)
+                    </span>
+                  @endif
                 </td>
               </tr>
             @endforeach

--- a/resources/views/empodat_suspect/statistics/substances_by_sample_code.blade.php
+++ b/resources/views/empodat_suspect/statistics/substances_by_sample_code.blade.php
@@ -32,13 +32,18 @@
           <div class="text-sm text-gray-600">Total Sample Codes</div>
           <div class="text-2xl font-bold text-gray-900">{{ number_format($totalSampleCodes, 0, '.', ' ') }}</div>
         </div>
+        @php
+          // Data shape per sample_code is ['total' => int, 'numeric' => int, 'non_numeric' => int].
+          // Sum the 'total' (or the bare int for legacy stats predating the partitioning split).
+          $totalSubstances = collect($data)->sum(fn ($v) => is_array($v) ? ($v['total'] ?? 0) : $v);
+        @endphp
         <div>
           <div class="text-sm text-gray-600">Total Substances (sum)</div>
-          <div class="text-2xl font-bold text-gray-900">{{ number_format(array_sum($data), 0, '.', ' ') }}</div>
+          <div class="text-2xl font-bold text-gray-900">{{ number_format($totalSubstances, 0, '.', ' ') }}</div>
         </div>
         <div>
           <div class="text-sm text-gray-600">Average Substances per Code</div>
-          <div class="text-2xl font-bold text-gray-900">{{ number_format(array_sum($data) / max($totalSampleCodes, 1), 1, '.', ' ') }}</div>
+          <div class="text-2xl font-bold text-gray-900">{{ number_format($totalSubstances / max($totalSampleCodes, 1), 1, '.', ' ') }}</div>
         </div>
       </div>
     </div>
@@ -58,13 +63,23 @@
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
-            @foreach(collect($data)->sortByDesc(function($count) { return $count; }) as $sampleCode => $count)
+            @foreach(collect($data)->sortByDesc(fn ($v) => is_array($v) ? ($v['total'] ?? 0) : $v) as $sampleCode => $info)
+              @php
+                $total       = is_array($info) ? ($info['total'] ?? 0)       : $info;
+                $numeric     = is_array($info) ? ($info['numeric'] ?? 0)     : 0;
+                $nonNumeric  = is_array($info) ? ($info['non_numeric'] ?? 0) : 0;
+              @endphp
               <tr>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                   {{ $sampleCode }}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  {{ number_format($count, 0, '.', ' ') }}
+                  {{ number_format($total, 0, '.', ' ') }}
+                  @if(is_array($info))
+                    <span class="text-xs text-gray-400 ml-2">
+                      ({{ number_format($numeric, 0, '.', ' ') }} numeric / {{ number_format($nonNumeric, 0, '.', ' ') }} N/A)
+                    </span>
+                  @endif
                 </td>
               </tr>
             @endforeach

--- a/tests/Feature/EmpodatSuspect/StatisticsDetailViewsTest.php
+++ b/tests/Feature/EmpodatSuspect/StatisticsDetailViewsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\EmpodatSuspect;
+
+use App\Models\DatabaseEntity;
+use App\Models\Statistic;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Regression: after the partitioning refactor the Action emits
+ * ['sample_code' => ['total' => int, 'numeric' => int, 'non_numeric' => int]]
+ * but the sample_code detail views called array_sum() on it, blowing up in
+ * production with "array_sum(): Addition is not supported on type array".
+ */
+class StatisticsDetailViewsTest extends TestCase
+{
+    public function test_sample_code_detail_pages_render_with_new_array_shape(): void
+    {
+        $entity = DatabaseEntity::firstOrCreate(
+            ['code' => 'empodat_suspect'],
+            [
+                'name' => 'Empodat Suspect (test)',
+                'is_public' => false,
+                'show_in_dashboard' => false,
+            ]
+        );
+
+        $newShape = [
+            'data' => [
+                'EE001' => ['total' => 100, 'numeric' => 70, 'non_numeric' => 30],
+                'EE002' => ['total' => 50,  'numeric' => 50, 'non_numeric' => 0],
+            ],
+            'total_sample_codes' => 2,
+            'generated_at' => now()->toISOString(),
+        ];
+
+        foreach (['empodat_suspect.records_by_sample_code', 'empodat_suspect.substances_by_sample_code'] as $key) {
+            Statistic::create([
+                'database_entity_id' => $entity->id,
+                'key' => $key,
+                'meta_data' => $newShape,
+            ]);
+        }
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $this->actingAs($user)
+            ->get(route('empodat_suspect.statistics.recordsBySampleCode'))
+            ->assertOk()
+            ->assertSee('EE001')
+            ->assertSee('70 numeric / 30 N/A', false);
+
+        $this->actingAs($user)
+            ->get(route('empodat_suspect.statistics.substancesBySampleCode'))
+            ->assertOk()
+            ->assertSee('EE001');
+    }
+
+    public function test_sample_code_detail_pages_still_render_with_legacy_int_shape(): void
+    {
+        $entity = DatabaseEntity::firstOrCreate(
+            ['code' => 'empodat_suspect'],
+            [
+                'name' => 'Empodat Suspect (test)',
+                'is_public' => false,
+                'show_in_dashboard' => false,
+            ]
+        );
+
+        $legacyShape = [
+            'data' => ['EE001' => 100, 'EE002' => 50],
+            'total_sample_codes' => 2,
+            'generated_at' => now()->toISOString(),
+        ];
+
+        foreach (['empodat_suspect.records_by_sample_code', 'empodat_suspect.substances_by_sample_code'] as $key) {
+            Statistic::create([
+                'database_entity_id' => $entity->id,
+                'key' => $key,
+                'meta_data' => $legacyShape,
+            ]);
+        }
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $this->actingAs($user)
+            ->get(route('empodat_suspect.statistics.recordsBySampleCode'))
+            ->assertOk()
+            ->assertSee('EE001');
+
+        $this->actingAs($user)
+            ->get(route('empodat_suspect.statistics.substancesBySampleCode'))
+            ->assertOk()
+            ->assertSee('EE001');
+    }
+}


### PR DESCRIPTION
## Bug

Sentry caught a 500 on `/empodat_suspect/statistics/records-by-sample-code` after the queued-statistics deploy:

```
ErrorException: array_sum(): Addition is not supported on type array
```

## Cause

The Action (introduced in #61) emits a richer shape for sample-code stats:

```diff
- ['EE001' => 100, 'EE002' => 50]                                     // old
+ ['EE001' => ['total' => 100, 'numeric' => 70, 'non_numeric' => 30]] // new
```

The country / confidence-interval views accessed `\$item['count']`, which the new shape preserves — they were unaffected. But the two sample-code detail views still called `array_sum(\$data)` on what is now an array of arrays.

## Fix

- Summary cards: replace `array_sum(\$data)` with `collect(\$data)->sum(fn (\$v) => is_array(\$v) ? (\$v['total'] ?? 0) : \$v)` so they work for the new shape AND legacy Statistic rows that predate the partitioning split.
- Table rows: display the total plus a small "(N numeric / N N/A)" suffix, matching the per-card style on the index page.
- New regression test covers both shapes (new arrays + legacy ints).

## Test plan

- [x] Pint clean
- [x] `php artisan test --filter=StatisticsDetailViewsTest` — 2 tests passing (new shape + legacy shape both render)
- [x] `php artisan test --filter=StatisticsGenerationTest` — still green
- [x] Manual: hit all 5 detail pages locally as super_admin, all 200