### PR TITLE
TerraChem suspect-screening import (4 sources, file IDs 10012–10015)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ yarn-error.log
 /.idea
 /.vscode
 
+# Temporary one-off scripts (DB checks, scratch) — never commit
+/_tmp
+
 # macOS Finder metadata — never commit
 .DS_Store
 **/.DS_Store

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the TerraChem INVERTEBRATE source file (id=10012) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the TerraChem INVERTEBRATE pipeline only.
+ * Called by EmpodatSuspectTerraChemInvertebrateSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectTerraChemInvertebrateFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10012],
+            [
+                'original_name' => 'TerraChem invertebrate samples 2026-06-03 upload ready.xlsx',
+                'name' => 'TerraChem INVERTEBRATE Suspect Screening Results',
+                'description' => 'TerraChem — suspect screening, INVERTEBRATE samples (biota matrix). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/TerraChem invertebrate samples 2026-06-03 upload ready.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateMainSeeder.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Database\Seeders\EmpodatSuspect\Traits\LoadsSubstanceCaches;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Stream TerraChem INVERTEBRATE xlsx → populate `empodat_suspect_main`,
+ * `empodat_suspect_metadata`, and `empodat_suspect_substances` in a single pass.
+ *
+ * Per source row:
+ *   - extract Block A/B/C fields (substance, IP, Units, …)
+ *   - extract Block E fields (HRMS metadata columns)
+ *   - accumulate unique (NORMAN_ID, Name) for end-of-run substances bulk insert
+ *   - find station columns (after `Units`, before `mz score`, minus `Blank ...` filler)
+ *   - for each non-NA station value: spawn one `empodat_suspect_main` row,
+ *     capture the returned id, spawn matching `empodat_suspect_metadata` row
+ *     with the same id + is_numeric_concentration.
+ *
+ * Single xlsx read (no separate substances pass) — see plan doc §3a.
+ *
+ * TerraChem deviations from BlackSea SEDIMENT:
+ *   - `Blank ...` filler columns between `Units` and the samples are skipped.
+ *   - HRMS column is spelled `numberoffragments score` (with "ber"), not
+ *     `numoffragments score` — reflected in METADATA_COLUMN_MAP below.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
+{
+    use LoadsSubstanceCaches;
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10012;
+
+    protected const FILE_NAME = 'TerraChem invertebrate samples 2026-06-03 upload ready.xlsx';
+
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    /** Source-column → empodat_suspect_metadata column name map (for Block E). */
+    protected const METADATA_COLUMN_MAP = [
+        'mz score' => 'mz_score',
+        'isotopicfit score' => 'isotopicfit_score',
+        'numberoffragments score' => 'numoffragments_score',
+        'DDAMSMS score' => 'ddamsms_score',
+        'molecularfitfragments score' => 'molecularfitfragments_score',
+        'rti score' => 'rti_score',
+        'spectral similarity' => 'spectral_similarity',
+        'RT avg' => 'rt_avg',
+        'Fragments' => 'fragments',
+        'Based_on_similarity' => 'based_on_similarity',
+        'Based_on_compound' => 'based_on_compound',
+        'Identification_Proofs' => 'identification_proofs',
+        'NumFragments' => 'num_fragments',
+    ];
+
+    /** Columns stored as double precision in empodat_suspect_metadata. */
+    protected const METADATA_DOUBLE_COLUMNS = [
+        'mz_score', 'isotopicfit_score', 'numoffragments_score', 'ddamsms_score',
+        'molecularfitfragments_score', 'rti_score', 'spectral_similarity', 'rt_avg',
+        'num_fragments',
+    ];
+
+    protected const BATCH_SIZE = 500;
+
+    public function run(): void
+    {
+        ini_set('memory_limit', '4G');
+        ini_set('max_execution_time', '7200');
+
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Loading lookup caches...');
+        $this->loadLookupCaches();
+
+        if (class_exists(\Laravel\Telescope\Telescope::class)) {
+            \Laravel\Telescope\Telescope::stopRecording();
+        }
+        DB::connection()->disableQueryLog();
+        DB::statement('SET session_replication_role = replica;');
+
+        $this->command->info('Streaming TerraChem INVERTEBRATE → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
+            .self::FILE_ID.')...');
+
+        $existingSubstances = DB::table('empodat_suspect_substances')
+            ->where('file_id', self::FILE_ID)
+            ->pluck('norman_id')
+            ->map(fn (?string $v): string => (string) $v)
+            ->flip()
+            ->all();
+
+        $reader = SimpleExcelReader::create($path);
+
+        $header = null;
+        $stationCols = [];
+        $mainBatch = [];
+        $metadataBatch = [];
+        $substancesByKey = [];
+        $rowCount = 0;
+        $insertedMain = 0;
+        $insertedSubstances = 0;
+        $skippedSourceRows = 0;
+        $startTime = microtime(true);
+
+        try {
+            foreach ($reader->getRows() as $sourceRow) {
+                if ($header === null) {
+                    $header = $this->cleanHeader(array_keys($sourceRow));
+                    $stationCols = $this->extractStationColumns($header);
+                    $this->command->info('  '.count($stationCols).' station columns identified for this source row.');
+                }
+
+                $rowCount++;
+
+                try {
+                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols, $substancesByKey, $existingSubstances);
+                } catch (\Throwable $e) {
+                    $skippedSourceRows++;
+                    if ($skippedSourceRows <= 10) {
+                        $this->command->error("  row {$rowCount}: ".$e->getMessage());
+                    }
+
+                    continue;
+                }
+
+                foreach ($mainRows as $mainRow) {
+                    $mainBatch[] = $mainRow;
+                    $metadataBatch[] = $metadataPayload + ['is_numeric_concentration' => $mainRow['is_numeric_concentration']];
+                }
+
+                if (count($mainBatch) >= self::BATCH_SIZE) {
+                    $this->flushBatch($mainBatch, $metadataBatch);
+                    $insertedMain += count($mainBatch);
+                    $mainBatch = [];
+                    $metadataBatch = [];
+                }
+
+                if ($rowCount % 200 === 0) {
+                    $rate = round($rowCount / (microtime(true) - $startTime), 1);
+                    $this->command->info("  processed {$rowCount} source rows, {$insertedMain} main rows inserted ({$rate} src rows/s)");
+                    gc_collect_cycles();
+                }
+            }
+
+            if (! empty($mainBatch)) {
+                $this->flushBatch($mainBatch, $metadataBatch);
+                $insertedMain += count($mainBatch);
+            }
+
+            $insertedSubstances = $this->insertSubstances($substancesByKey);
+        } finally {
+            DB::statement('SET session_replication_role = default;');
+            DB::connection()->enableQueryLog();
+            if (class_exists(\Laravel\Telescope\Telescope::class)) {
+                \Laravel\Telescope\Telescope::startRecording();
+            }
+        }
+
+        $totalTime = round(microtime(true) - $startTime, 2);
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows, {$insertedSubstances} substances.");
+        if ($skippedSourceRows > 0) {
+            $this->command->warn("Skipped {$skippedSourceRows} source rows due to errors.");
+        }
+
+        $this->validateSubstanceIds(self::FILE_ID);
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRow
+     * @param  array<int, string>  $stationCols
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     * @param  array<string, int>  $existingSubstances
+     * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
+     */
+    protected function buildRows(array $sourceRow, array $stationCols, array &$substancesByKey, array $existingSubstances): array
+    {
+        $normanId = $this->cleanString($sourceRow['NORMAN_ID'] ?? null);
+        if ($normanId === null) {
+            return [[], []];
+        }
+
+        $name = $this->cleanString($sourceRow['Name'] ?? null);
+        if ($name !== null && ! isset($existingSubstances[$normanId])) {
+            $key = $normanId.'|'.$name;
+            $substancesByKey[$key] ??= [
+                'norman_id' => $normanId,
+                'name' => $name,
+                'file_id' => self::FILE_ID,
+            ];
+        }
+
+        $code = preg_replace('/^NS/i', '', $normanId) ?? '';
+        $substanceId = $this->resolveSubstanceId($code);
+
+        $ip = $this->cleanString($sourceRow['IP'] ?? null);
+        $ipMax = $this->cleanDouble($sourceRow['IP_max'] ?? null);
+        $basedOnHrms = $this->cleanBoolean($sourceRow['BasedonHRMSLibrary'] ?? null);
+        $units = $this->cleanString($sourceRow['Units'] ?? null);
+        $method = $this->cleanString($sourceRow['Method'] ?? null);
+
+        $metadataPayload = ['method' => $method];
+        foreach (self::METADATA_COLUMN_MAP as $sourceCol => $destCol) {
+            $raw = $sourceRow[$sourceCol] ?? null;
+            if (in_array($destCol, self::METADATA_DOUBLE_COLUMNS, true)) {
+                $metadataPayload[$destCol] = $this->cleanDouble($raw);
+            } else {
+                $metadataPayload[$destCol] = $this->cleanString($raw);
+            }
+        }
+
+        $mainRows = [];
+        foreach ($stationCols as $colName) {
+            $raw = $sourceRow[$colName] ?? null;
+            if ($raw === null || $raw === '') {
+                continue;
+            }
+
+            $mapping = $this->stationMappingCache[$colName] ?? null;
+            if ($mapping === null) {
+                continue;
+            }
+
+            $concentration = $this->cleanDouble($raw);
+            $isNumeric = $concentration !== null;
+
+            $mainRows[] = [
+                'file_id' => self::FILE_ID,
+                'is_numeric_concentration' => $isNumeric,
+                'substance_id' => $substanceId,
+                'xlsx_station_mapping_id' => $mapping['mapping_id'],
+                'station_id' => $mapping['station_id'],
+                'concentration' => $concentration,
+                'ip' => $ip,
+                'ip_max' => $ipMax,
+                'based_on_hrms_library' => $basedOnHrms,
+                'units' => $units,
+            ];
+        }
+
+        return [$mainRows, $metadataPayload];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $mainBatch
+     * @param  array<int, array<string, mixed>>  $metadataBatch
+     */
+    protected function flushBatch(array $mainBatch, array $metadataBatch): void
+    {
+        if (count($mainBatch) !== count($metadataBatch)) {
+            throw new \LogicException('main/metadata batch length mismatch: '
+                .count($mainBatch).' vs '.count($metadataBatch));
+        }
+
+        DB::transaction(function () use ($mainBatch, $metadataBatch): void {
+            $mainCols = array_keys($mainBatch[0]);
+            $placeholders = '('.implode(', ', array_fill(0, count($mainCols), '?')).')';
+            $valuesSql = implode(', ', array_fill(0, count($mainBatch), $placeholders));
+            $colsSql = implode(', ', $mainCols);
+
+            $bindings = [];
+            foreach ($mainBatch as $row) {
+                foreach ($mainCols as $col) {
+                    $bindings[] = $row[$col];
+                }
+            }
+
+            $sql = "INSERT INTO empodat_suspect_main ({$colsSql}) VALUES {$valuesSql} "
+                .'RETURNING id, is_numeric_concentration';
+            $returned = DB::select($sql, $bindings);
+
+            if (count($returned) !== count($mainBatch)) {
+                throw new \RuntimeException('RETURNING count mismatch: '
+                    .count($returned).' vs expected '.count($mainBatch));
+            }
+
+            $metadataInsert = [];
+            foreach ($returned as $i => $r) {
+                $metadataInsert[] = $metadataBatch[$i] + [
+                    'id' => $r->id,
+                    'is_numeric_concentration' => $r->is_numeric_concentration,
+                ];
+            }
+            DB::table('empodat_suspect_metadata')->insert($metadataInsert);
+        });
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     */
+    protected function insertSubstances(array $substancesByKey): int
+    {
+        if (empty($substancesByKey)) {
+            return 0;
+        }
+
+        $rows = array_values($substancesByKey);
+        $inserted = 0;
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('empodat_suspect_substances')->insert($chunk);
+            $inserted += count($chunk);
+        }
+
+        return $inserted;
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+            if ($name === '' || $name === null) {
+                continue;
+            }
+            if (stripos($name, 'Blank') === 0) {
+                continue;
+            }
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+
+    protected function cleanString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+
+        return ($cleaned === '' || $cleaned === 'NA') ? null : $cleaned;
+    }
+
+    protected function cleanDouble(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+
+        return is_numeric($cleaned) ? (float) $cleaned : null;
+    }
+
+    protected function cleanBoolean(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = strtoupper(trim((string) $value));
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+        if (in_array($cleaned, ['TRUE', '1', 'YES'], true)) {
+            return true;
+        }
+        if (in_array($cleaned, ['FALSE', '0', 'NO'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * TerraChem INVERTEBRATE pipeline — full end-to-end import in one command.
+ *
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10012 only):
+ *   1. TerraChemInvertebrateFileSeeder — register THIS file row in `files` (id=10012 only)
+ *   2. XlsxStationsMapping             — insert 83 station-column rows for file_id=10012
+ *   3. XlsxStationsMappingFill         — resolve station_id via equality on short_sample_code
+ *   4. Main+Metadata                   — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                        + empodat_suspect_substances (all in one pass)
+ *
+ * All phases are idempotent — safe to re-run. ⚠️ Main+Metadata adds to existing
+ * data; truncate `empodat_suspect_main`/`empodat_suspect_metadata` for file_id=10012
+ * first if re-seeding from scratch.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateSeeder
+ */
+class EmpodatSuspectTerraChemInvertebrateSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== TerraChem INVERTEBRATE pipeline (file_id=10012) ===');
+
+        $this->call([
+            EmpodatSuspectTerraChemInvertebrateFileSeeder::class,
+            EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingSeeder::class,
+            EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectTerraChemInvertebrateMainSeeder::class,
+        ]);
+
+        $this->command->info('=== TerraChem INVERTEBRATE pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for TerraChem INVERTEBRATE mapping rows via direct lowercase
+ * equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10012. Handles non-uniqueness via MIN(s.id) + STRING_AGG.
+ * Excludes deprecated stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10012;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for TerraChem INVERTEBRATE mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingSeeder.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from TerraChem INVERTEBRATE into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/TerraChem invertebrate samples 2026-06-03 upload ready.xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary), MINUS any 'Blank ...' filler column. Expected: 83 stations.
+ *
+ * Differs from BlackSea SEDIMENT only in the Blank-column skip: TerraChem files
+ * carry 1–5 'Blank ...' columns between 'Units' and the first sample column.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10012;
+
+    protected const FILE_NAME = 'TerraChem invertebrate samples 2026-06-03 upload ready.xlsx';
+
+    /** Structural marker: station columns begin AFTER this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker: HRMS metadata block (mz score, isotopicfit score, ...) begins HERE. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from TerraChem INVERTEBRATE (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            if (stripos($name, 'Blank') === 0) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateXlsxStationsMappingSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the TerraChem PLANT source file (id=10013) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the TerraChem PLANT pipeline only.
+ * Called by EmpodatSuspectTerraChemPlantSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectTerraChemPlantFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10013],
+            [
+                'original_name' => 'TerraChem plant samples 2026-06-03 upload ready.xlsx',
+                'name' => 'TerraChem PLANT Suspect Screening Results',
+                'description' => 'TerraChem — suspect screening, PLANT samples (biota matrix). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/TerraChem plant samples 2026-06-03 upload ready.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemPlantFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantMainSeeder.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Spatie\SimpleExcel\SimpleExcelReader;
 
 /**
- * Stream TerraChem INVERTEBRATE xlsx → populate `empodat_suspect_main`,
+ * Stream TerraChem PLANT xlsx → populate `empodat_suspect_main`,
  * `empodat_suspect_metadata`, and `empodat_suspect_substances` in a single pass.
  *
  * Per source row:
@@ -30,16 +30,22 @@ use Spatie\SimpleExcel\SimpleExcelReader;
  *   - HRMS column is spelled `numberoffragments score` (with "ber"), not
  *     `numoffragments score` — reflected in METADATA_COLUMN_MAP below.
  *
+ * PLANT-only deviations:
+ *   - The "based on HRMS library" column is spelled `Basedon HRMSLibrary` (with a
+ *     space) in this file, not `BasedonHRMSLibrary` — read accordingly in buildRows().
+ *   - A stray `Unit` column sits inside Block C; it is not in METADATA_COLUMN_MAP
+ *     and is therefore ignored. `Identification_Proofs` is absent (stored as null).
+ *
  * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
  */
-class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
+class EmpodatSuspectTerraChemPlantMainSeeder extends Seeder
 {
     use LoadsSubstanceCaches;
     use WithoutModelEvents;
 
-    protected const FILE_ID = 10012;
+    protected const FILE_ID = 10013;
 
-    protected const FILE_NAME = 'TerraChem invertebrate samples 2026-06-03 upload ready.xlsx';
+    protected const FILE_NAME = 'TerraChem plant samples 2026-06-03 upload ready.xlsx';
 
     protected const STATION_BLOCK_START_AFTER = 'Units';
 
@@ -97,7 +103,7 @@ class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
 
-        $this->command->info('Streaming TerraChem INVERTEBRATE → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
+        $this->command->info('Streaming TerraChem PLANT → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');
 
         $existingSubstances = DB::table('empodat_suspect_substances')
@@ -212,7 +218,8 @@ class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
 
         $ip = $this->cleanString($sourceRow['IP'] ?? null);
         $ipMax = $this->cleanDouble($sourceRow['IP_max'] ?? null);
-        $basedOnHrms = $this->cleanBoolean($sourceRow['BasedonHRMSLibrary'] ?? null);
+        // PLANT file spells this column with a space: `Basedon HRMSLibrary`.
+        $basedOnHrms = $this->cleanBoolean($sourceRow['Basedon HRMSLibrary'] ?? null);
         $units = $this->cleanString($sourceRow['Units'] ?? null);
         $method = $this->cleanString($sourceRow['Method'] ?? null);
 
@@ -405,4 +412,4 @@ class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
         return null;
     }
 }
-// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateMainSeeder
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemPlantMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * TerraChem PLANT pipeline — full end-to-end import in one command.
+ *
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10013 only):
+ *   1. TerraChemPlantFileSeeder — register THIS file row in `files` (id=10013 only)
+ *   2. XlsxStationsMapping       — insert 71 station-column rows for file_id=10013
+ *   3. XlsxStationsMappingFill   — resolve station_id via equality on short_sample_code
+ *   4. Main+Metadata             — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                  + empodat_suspect_substances (all in one pass)
+ *
+ * All phases are idempotent — safe to re-run. ⚠️ Main+Metadata adds to existing
+ * data; truncate `empodat_suspect_main`/`empodat_suspect_metadata` for file_id=10013
+ * first if re-seeding from scratch.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemPlantSeeder
+ */
+class EmpodatSuspectTerraChemPlantSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== TerraChem PLANT pipeline (file_id=10013) ===');
+
+        $this->call([
+            EmpodatSuspectTerraChemPlantFileSeeder::class,
+            EmpodatSuspectTerraChemPlantXlsxStationsMappingSeeder::class,
+            EmpodatSuspectTerraChemPlantXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectTerraChemPlantMainSeeder::class,
+        ]);
+
+        $this->command->info('=== TerraChem PLANT pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for TerraChem PLANT mapping rows via direct lowercase
+ * equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10013. Handles non-uniqueness via MIN(s.id) + STRING_AGG.
+ * Excludes deprecated stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemPlantXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10013;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for TerraChem PLANT mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemPlantXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantXlsxStationsMappingSeeder.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from TerraChem PLANT into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/TerraChem plant samples 2026-06-03 upload ready.xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary), MINUS any 'Blank ...' filler column. Expected: 71 stations.
+ *
+ * Differs from BlackSea SEDIMENT only in the Blank-column skip: TerraChem files
+ * carry 1–5 'Blank ...' columns between 'Units' and the first sample column.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemPlantXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10013;
+
+    protected const FILE_NAME = 'TerraChem plant samples 2026-06-03 upload ready.xlsx';
+
+    /** Structural marker: station columns begin AFTER this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker: HRMS metadata block (mz score, isotopicfit score, ...) begins HERE. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from TerraChem PLANT (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            if (stripos($name, 'Blank') === 0) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemPlantXlsxStationsMappingSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the TerraChem RODENT source file (id=10014) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the TerraChem RODENT pipeline only.
+ * Called by EmpodatSuspectTerraChemRodentSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectTerraChemRodentFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10014],
+            [
+                'original_name' => 'TerraChem rodent and predator samples 2026-06-03 upload ready.xlsx',
+                'name' => 'TerraChem RODENT Suspect Screening Results',
+                'description' => 'TerraChem — suspect screening, RODENT and predator samples (biota matrix). Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/TerraChem rodent and predator samples 2026-06-03 upload ready.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemRodentFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentMainSeeder.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Spatie\SimpleExcel\SimpleExcelReader;
 
 /**
- * Stream TerraChem INVERTEBRATE xlsx → populate `empodat_suspect_main`,
+ * Stream TerraChem RODENT xlsx → populate `empodat_suspect_main`,
  * `empodat_suspect_metadata`, and `empodat_suspect_substances` in a single pass.
  *
  * Per source row:
@@ -29,17 +29,18 @@ use Spatie\SimpleExcel\SimpleExcelReader;
  *   - `Blank ...` filler columns between `Units` and the samples are skipped.
  *   - HRMS column is spelled `numberoffragments score` (with "ber"), not
  *     `numoffragments score` — reflected in METADATA_COLUMN_MAP below.
+ *   - `Identification_Proofs` is absent in this file (stored as null).
  *
  * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
  */
-class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
+class EmpodatSuspectTerraChemRodentMainSeeder extends Seeder
 {
     use LoadsSubstanceCaches;
     use WithoutModelEvents;
 
-    protected const FILE_ID = 10012;
+    protected const FILE_ID = 10014;
 
-    protected const FILE_NAME = 'TerraChem invertebrate samples 2026-06-03 upload ready.xlsx';
+    protected const FILE_NAME = 'TerraChem rodent and predator samples 2026-06-03 upload ready.xlsx';
 
     protected const STATION_BLOCK_START_AFTER = 'Units';
 
@@ -97,7 +98,7 @@ class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
 
-        $this->command->info('Streaming TerraChem INVERTEBRATE → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
+        $this->command->info('Streaming TerraChem RODENT → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');
 
         $existingSubstances = DB::table('empodat_suspect_substances')
@@ -405,4 +406,4 @@ class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
         return null;
     }
 }
-// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemInvertebrateMainSeeder
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemRodentMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * TerraChem RODENT pipeline — full end-to-end import in one command.
+ *
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10014 only):
+ *   1. TerraChemRodentFileSeeder — register THIS file row in `files` (id=10014 only)
+ *   2. XlsxStationsMapping        — insert 162 station-column rows for file_id=10014
+ *   3. XlsxStationsMappingFill    — resolve station_id via equality on short_sample_code
+ *   4. Main+Metadata              — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                   + empodat_suspect_substances (all in one pass)
+ *
+ * All phases are idempotent — safe to re-run. ⚠️ Main+Metadata adds to existing
+ * data; truncate `empodat_suspect_main`/`empodat_suspect_metadata` for file_id=10014
+ * first if re-seeding from scratch.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemRodentSeeder
+ */
+class EmpodatSuspectTerraChemRodentSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== TerraChem RODENT pipeline (file_id=10014) ===');
+
+        $this->call([
+            EmpodatSuspectTerraChemRodentFileSeeder::class,
+            EmpodatSuspectTerraChemRodentXlsxStationsMappingSeeder::class,
+            EmpodatSuspectTerraChemRodentXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectTerraChemRodentMainSeeder::class,
+        ]);
+
+        $this->command->info('=== TerraChem RODENT pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for TerraChem RODENT mapping rows via direct lowercase
+ * equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10014. Handles non-uniqueness via MIN(s.id) + STRING_AGG.
+ * Excludes deprecated stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemRodentXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10014;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for TerraChem RODENT mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemRodentXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentXlsxStationsMappingSeeder.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from TerraChem RODENT into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/TerraChem rodent and predator samples 2026-06-03 upload ready.xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary), MINUS any 'Blank ...' filler column. Expected: 162 stations.
+ *
+ * Differs from BlackSea SEDIMENT only in the Blank-column skip: TerraChem files
+ * carry 1–5 'Blank ...' columns between 'Units' and the first sample column.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemRodentXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10014;
+
+    protected const FILE_NAME = 'TerraChem rodent and predator samples 2026-06-03 upload ready.xlsx';
+
+    /** Structural marker: station columns begin AFTER this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker: HRMS metadata block (mz score, isotopicfit score, ...) begins HERE. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from TerraChem RODENT (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            if (stripos($name, 'Blank') === 0) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemRodentXlsxStationsMappingSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilFileSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilFileSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use App\Models\Backend\File;
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * Register the TerraChem SOIL source file (id=10015) in the `files` table.
+ *
+ * One-file FileSeeder — scoped to the TerraChem SOIL pipeline only.
+ * Called by EmpodatSuspectTerraChemSoilSeeder so the orchestrator doesn't
+ * touch unrelated file rows.
+ *
+ * Idempotent (updateOrCreate by id).
+ */
+class EmpodatSuspectTerraChemSoilFileSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $file = File::updateOrCreate(
+            ['id' => 10015],
+            [
+                'original_name' => 'TerraChem soil samples 2026-06-03 upload ready.xlsx',
+                'name' => 'TerraChem SOIL Suspect Screening Results',
+                'description' => 'TerraChem — suspect screening, SOIL matrix. Includes HRMS identification metadata stored in empodat_suspect_metadata.',
+                'file_path' => 'empodat_suspect/TerraChem soil samples 2026-06-03 upload ready.xlsx',
+                'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'database_entity_id' => 18,
+                'uploaded_at' => Carbon::now(),
+                'is_deleted' => false,
+            ]
+        );
+
+        $verb = $file->wasRecentlyCreated ? 'Created' : 'Updated';
+        $this->command->info("{$verb} File ID {$file->id}: {$file->name}");
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemSoilFileSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilMainSeeder.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Database\Seeders\EmpodatSuspect\Traits\LoadsSubstanceCaches;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Stream TerraChem SOIL xlsx → populate `empodat_suspect_main`,
+ * `empodat_suspect_metadata`, and `empodat_suspect_substances` in a single pass.
+ *
+ * Per source row:
+ *   - extract Block A/B/C fields (substance, IP, Units, …)
+ *   - extract Block E fields (HRMS metadata columns)
+ *   - accumulate unique (NORMAN_ID, Name) for end-of-run substances bulk insert
+ *   - find station columns (after `Units`, before `mz score`, minus `Blank ...` filler)
+ *   - for each non-NA station value: spawn one `empodat_suspect_main` row,
+ *     capture the returned id, spawn matching `empodat_suspect_metadata` row
+ *     with the same id + is_numeric_concentration.
+ *
+ * Single xlsx read (no separate substances pass) — see plan doc §3a.
+ *
+ * TerraChem deviations from BlackSea SEDIMENT:
+ *   - `Blank ...` filler columns between `Units` and the samples are skipped.
+ *   - HRMS column is spelled `numberoffragments score` (with "ber"), not
+ *     `numoffragments score` — reflected in METADATA_COLUMN_MAP below.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemSoilMainSeeder extends Seeder
+{
+    use LoadsSubstanceCaches;
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10015;
+
+    protected const FILE_NAME = 'TerraChem soil samples 2026-06-03 upload ready.xlsx';
+
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    /** Source-column → empodat_suspect_metadata column name map (for Block E). */
+    protected const METADATA_COLUMN_MAP = [
+        'mz score' => 'mz_score',
+        'isotopicfit score' => 'isotopicfit_score',
+        'numberoffragments score' => 'numoffragments_score',
+        'DDAMSMS score' => 'ddamsms_score',
+        'molecularfitfragments score' => 'molecularfitfragments_score',
+        'rti score' => 'rti_score',
+        'spectral similarity' => 'spectral_similarity',
+        'RT avg' => 'rt_avg',
+        'Fragments' => 'fragments',
+        'Based_on_similarity' => 'based_on_similarity',
+        'Based_on_compound' => 'based_on_compound',
+        'Identification_Proofs' => 'identification_proofs',
+        'NumFragments' => 'num_fragments',
+    ];
+
+    /** Columns stored as double precision in empodat_suspect_metadata. */
+    protected const METADATA_DOUBLE_COLUMNS = [
+        'mz_score', 'isotopicfit_score', 'numoffragments_score', 'ddamsms_score',
+        'molecularfitfragments_score', 'rti_score', 'spectral_similarity', 'rt_avg',
+        'num_fragments',
+    ];
+
+    protected const BATCH_SIZE = 500;
+
+    public function run(): void
+    {
+        ini_set('memory_limit', '4G');
+        ini_set('max_execution_time', '7200');
+
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Loading lookup caches...');
+        $this->loadLookupCaches();
+
+        if (class_exists(\Laravel\Telescope\Telescope::class)) {
+            \Laravel\Telescope\Telescope::stopRecording();
+        }
+        DB::connection()->disableQueryLog();
+        DB::statement('SET session_replication_role = replica;');
+
+        $this->command->info('Streaming TerraChem SOIL → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
+            .self::FILE_ID.')...');
+
+        $existingSubstances = DB::table('empodat_suspect_substances')
+            ->where('file_id', self::FILE_ID)
+            ->pluck('norman_id')
+            ->map(fn (?string $v): string => (string) $v)
+            ->flip()
+            ->all();
+
+        $reader = SimpleExcelReader::create($path);
+
+        $header = null;
+        $stationCols = [];
+        $mainBatch = [];
+        $metadataBatch = [];
+        $substancesByKey = [];
+        $rowCount = 0;
+        $insertedMain = 0;
+        $insertedSubstances = 0;
+        $skippedSourceRows = 0;
+        $startTime = microtime(true);
+
+        try {
+            foreach ($reader->getRows() as $sourceRow) {
+                if ($header === null) {
+                    $header = $this->cleanHeader(array_keys($sourceRow));
+                    $stationCols = $this->extractStationColumns($header);
+                    $this->command->info('  '.count($stationCols).' station columns identified for this source row.');
+                }
+
+                $rowCount++;
+
+                try {
+                    [$mainRows, $metadataPayload] = $this->buildRows($sourceRow, $stationCols, $substancesByKey, $existingSubstances);
+                } catch (\Throwable $e) {
+                    $skippedSourceRows++;
+                    if ($skippedSourceRows <= 10) {
+                        $this->command->error("  row {$rowCount}: ".$e->getMessage());
+                    }
+
+                    continue;
+                }
+
+                foreach ($mainRows as $mainRow) {
+                    $mainBatch[] = $mainRow;
+                    $metadataBatch[] = $metadataPayload + ['is_numeric_concentration' => $mainRow['is_numeric_concentration']];
+                }
+
+                if (count($mainBatch) >= self::BATCH_SIZE) {
+                    $this->flushBatch($mainBatch, $metadataBatch);
+                    $insertedMain += count($mainBatch);
+                    $mainBatch = [];
+                    $metadataBatch = [];
+                }
+
+                if ($rowCount % 200 === 0) {
+                    $rate = round($rowCount / (microtime(true) - $startTime), 1);
+                    $this->command->info("  processed {$rowCount} source rows, {$insertedMain} main rows inserted ({$rate} src rows/s)");
+                    gc_collect_cycles();
+                }
+            }
+
+            if (! empty($mainBatch)) {
+                $this->flushBatch($mainBatch, $metadataBatch);
+                $insertedMain += count($mainBatch);
+            }
+
+            $insertedSubstances = $this->insertSubstances($substancesByKey);
+        } finally {
+            DB::statement('SET session_replication_role = default;');
+            DB::connection()->enableQueryLog();
+            if (class_exists(\Laravel\Telescope\Telescope::class)) {
+                \Laravel\Telescope\Telescope::startRecording();
+            }
+        }
+
+        $totalTime = round(microtime(true) - $startTime, 2);
+        $this->command->info("Done in {$totalTime}s — processed {$rowCount} source rows, inserted {$insertedMain} main+metadata rows, {$insertedSubstances} substances.");
+        if ($skippedSourceRows > 0) {
+            $this->command->warn("Skipped {$skippedSourceRows} source rows due to errors.");
+        }
+
+        $this->validateSubstanceIds(self::FILE_ID);
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRow
+     * @param  array<int, string>  $stationCols
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     * @param  array<string, int>  $existingSubstances
+     * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
+     */
+    protected function buildRows(array $sourceRow, array $stationCols, array &$substancesByKey, array $existingSubstances): array
+    {
+        $normanId = $this->cleanString($sourceRow['NORMAN_ID'] ?? null);
+        if ($normanId === null) {
+            return [[], []];
+        }
+
+        $name = $this->cleanString($sourceRow['Name'] ?? null);
+        if ($name !== null && ! isset($existingSubstances[$normanId])) {
+            $key = $normanId.'|'.$name;
+            $substancesByKey[$key] ??= [
+                'norman_id' => $normanId,
+                'name' => $name,
+                'file_id' => self::FILE_ID,
+            ];
+        }
+
+        $code = preg_replace('/^NS/i', '', $normanId) ?? '';
+        $substanceId = $this->resolveSubstanceId($code);
+
+        $ip = $this->cleanString($sourceRow['IP'] ?? null);
+        $ipMax = $this->cleanDouble($sourceRow['IP_max'] ?? null);
+        $basedOnHrms = $this->cleanBoolean($sourceRow['BasedonHRMSLibrary'] ?? null);
+        $units = $this->cleanString($sourceRow['Units'] ?? null);
+        $method = $this->cleanString($sourceRow['Method'] ?? null);
+
+        $metadataPayload = ['method' => $method];
+        foreach (self::METADATA_COLUMN_MAP as $sourceCol => $destCol) {
+            $raw = $sourceRow[$sourceCol] ?? null;
+            if (in_array($destCol, self::METADATA_DOUBLE_COLUMNS, true)) {
+                $metadataPayload[$destCol] = $this->cleanDouble($raw);
+            } else {
+                $metadataPayload[$destCol] = $this->cleanString($raw);
+            }
+        }
+
+        $mainRows = [];
+        foreach ($stationCols as $colName) {
+            $raw = $sourceRow[$colName] ?? null;
+            if ($raw === null || $raw === '') {
+                continue;
+            }
+
+            $mapping = $this->stationMappingCache[$colName] ?? null;
+            if ($mapping === null) {
+                continue;
+            }
+
+            $concentration = $this->cleanDouble($raw);
+            $isNumeric = $concentration !== null;
+
+            $mainRows[] = [
+                'file_id' => self::FILE_ID,
+                'is_numeric_concentration' => $isNumeric,
+                'substance_id' => $substanceId,
+                'xlsx_station_mapping_id' => $mapping['mapping_id'],
+                'station_id' => $mapping['station_id'],
+                'concentration' => $concentration,
+                'ip' => $ip,
+                'ip_max' => $ipMax,
+                'based_on_hrms_library' => $basedOnHrms,
+                'units' => $units,
+            ];
+        }
+
+        return [$mainRows, $metadataPayload];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $mainBatch
+     * @param  array<int, array<string, mixed>>  $metadataBatch
+     */
+    protected function flushBatch(array $mainBatch, array $metadataBatch): void
+    {
+        if (count($mainBatch) !== count($metadataBatch)) {
+            throw new \LogicException('main/metadata batch length mismatch: '
+                .count($mainBatch).' vs '.count($metadataBatch));
+        }
+
+        DB::transaction(function () use ($mainBatch, $metadataBatch): void {
+            $mainCols = array_keys($mainBatch[0]);
+            $placeholders = '('.implode(', ', array_fill(0, count($mainCols), '?')).')';
+            $valuesSql = implode(', ', array_fill(0, count($mainBatch), $placeholders));
+            $colsSql = implode(', ', $mainCols);
+
+            $bindings = [];
+            foreach ($mainBatch as $row) {
+                foreach ($mainCols as $col) {
+                    $bindings[] = $row[$col];
+                }
+            }
+
+            $sql = "INSERT INTO empodat_suspect_main ({$colsSql}) VALUES {$valuesSql} "
+                .'RETURNING id, is_numeric_concentration';
+            $returned = DB::select($sql, $bindings);
+
+            if (count($returned) !== count($mainBatch)) {
+                throw new \RuntimeException('RETURNING count mismatch: '
+                    .count($returned).' vs expected '.count($mainBatch));
+            }
+
+            $metadataInsert = [];
+            foreach ($returned as $i => $r) {
+                $metadataInsert[] = $metadataBatch[$i] + [
+                    'id' => $r->id,
+                    'is_numeric_concentration' => $r->is_numeric_concentration,
+                ];
+            }
+            DB::table('empodat_suspect_metadata')->insert($metadataInsert);
+        });
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $substancesByKey
+     */
+    protected function insertSubstances(array $substancesByKey): int
+    {
+        if (empty($substancesByKey)) {
+            return 0;
+        }
+
+        $rows = array_values($substancesByKey);
+        $inserted = 0;
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('empodat_suspect_substances')->insert($chunk);
+            $inserted += count($chunk);
+        }
+
+        return $inserted;
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+            if ($name === '' || $name === null) {
+                continue;
+            }
+            if (stripos($name, 'Blank') === 0) {
+                continue;
+            }
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+
+    protected function cleanString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+
+        return ($cleaned === '' || $cleaned === 'NA') ? null : $cleaned;
+    }
+
+    protected function cleanDouble(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = trim((string) $value);
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+
+        return is_numeric($cleaned) ? (float) $cleaned : null;
+    }
+
+    protected function cleanBoolean(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $cleaned = strtoupper(trim((string) $value));
+        if ($cleaned === '' || $cleaned === 'NA') {
+            return null;
+        }
+        if (in_array($cleaned, ['TRUE', '1', 'YES'], true)) {
+            return true;
+        }
+        if (in_array($cleaned, ['FALSE', '0', 'NO'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemSoilMainSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilMainSeeder.php
@@ -69,11 +69,16 @@ class EmpodatSuspectTerraChemSoilMainSeeder extends Seeder
         'num_fragments',
     ];
 
-    protected const BATCH_SIZE = 500;
+    /**
+     * Rows per multi-row INSERT. Capped by Postgres' 65535 bind-parameter limit:
+     * empodat_suspect_metadata is the widest write at 16 columns → 16 × 4000 =
+     * 64000 < 65535. Larger batches = far fewer round-trips = faster import.
+     */
+    protected const BATCH_SIZE = 4000;
 
     public function run(): void
     {
-        ini_set('memory_limit', '4G');
+        ini_set('memory_limit', '16G');
         ini_set('max_execution_time', '7200');
 
         $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+/**
+ * TerraChem SOIL pipeline — full end-to-end import in one command.
+ *
+ * Phases (4-step, optimised single xlsx read, scoped to file_id=10015 only):
+ *   1. TerraChemSoilFileSeeder  — register THIS file row in `files` (id=10015 only)
+ *   2. XlsxStationsMapping      — insert 54 station-column rows for file_id=10015
+ *   3. XlsxStationsMappingFill  — resolve station_id via equality on short_sample_code
+ *   4. Main+Metadata            — stream xlsx → empodat_suspect_main + empodat_suspect_metadata
+ *                                 + empodat_suspect_substances (all in one pass)
+ *
+ * All phases are idempotent — safe to re-run. ⚠️ Main+Metadata adds to existing
+ * data; truncate `empodat_suspect_main`/`empodat_suspect_metadata` for file_id=10015
+ * first if re-seeding from scratch.
+ *
+ * php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemSoilSeeder
+ */
+class EmpodatSuspectTerraChemSoilSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $this->command->info('=== TerraChem SOIL pipeline (file_id=10015) ===');
+
+        $this->call([
+            EmpodatSuspectTerraChemSoilFileSeeder::class,
+            EmpodatSuspectTerraChemSoilXlsxStationsMappingSeeder::class,
+            EmpodatSuspectTerraChemSoilXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectTerraChemSoilMainSeeder::class,
+        ]);
+
+        $this->command->info('=== TerraChem SOIL pipeline complete ===');
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilXlsxStationsMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilXlsxStationsMappingFillSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolve station_id for TerraChem SOIL mapping rows via direct lowercase
+ * equality on empodat_stations.short_sample_code.
+ *
+ * Scoped to file_id = 10015. Handles non-uniqueness via MIN(s.id) + STRING_AGG.
+ * Excludes deprecated stations.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemSoilXlsxStationsMappingFillSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10015;
+
+    public function run(): void
+    {
+        $this->command->info('Resolving station_id for TerraChem SOIL mapping rows (file_id='.self::FILE_ID.')...');
+
+        $sql = <<<'SQL'
+            UPDATE empodat_suspect_xlsx_stations_mapping AS m
+            SET
+                station_id = sub.first_station_id,
+                count      = sub.station_count,
+                ids        = sub.all_station_ids,
+                updated_at = NOW()
+            FROM (
+                SELECT
+                    m.id AS mapping_id,
+                    MIN(s.id)                                     AS first_station_id,
+                    COUNT(s.id)                                   AS station_count,
+                    STRING_AGG(s.id::text, ', ' ORDER BY s.id)    AS all_station_ids
+                FROM empodat_suspect_xlsx_stations_mapping AS m
+                LEFT JOIN empodat_stations AS s
+                  ON LOWER(s.short_sample_code) = LOWER(m.xlsx_name)
+                 AND (s.is_deprecated IS NULL OR s.is_deprecated = FALSE)
+                WHERE m.file_id = :file_id
+                GROUP BY m.id
+            ) AS sub
+            WHERE m.id = sub.mapping_id
+        SQL;
+
+        $affected = DB::update($sql, ['file_id' => self::FILE_ID]);
+
+        $this->command->info("Updated {$affected} mapping rows.");
+        $this->reportUnresolved();
+    }
+
+    protected function reportUnresolved(): void
+    {
+        $unresolved = DB::table('empodat_suspect_xlsx_stations_mapping')
+            ->where('file_id', self::FILE_ID)
+            ->whereNull('station_id')
+            ->pluck('xlsx_name')
+            ->all();
+
+        if (empty($unresolved)) {
+            $this->command->info('All headers resolved for file_id='.self::FILE_ID.'.');
+
+            return;
+        }
+
+        $this->command->warn(count($unresolved).' headers still unresolved for file_id='.self::FILE_ID.':');
+        foreach ($unresolved as $name) {
+            $this->command->warn('  - '.$name);
+        }
+        $this->command->warn('Append these to EMPODAT_SUSPECT-mapping-JS-<date>.csv and run EmpodatSuspectManualMappingFillSeeder.');
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemSoilXlsxStationsMappingFillSeeder

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilXlsxStationsMappingSeeder.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\SimpleExcel\SimpleExcelReader;
+
+/**
+ * Insert one row per station column from TerraChem SOIL into
+ * empodat_suspect_xlsx_stations_mapping (with station_id NULL — the Fill
+ * seeder resolves it via LOWER(short_sample_code) = LOWER(xlsx_name)).
+ *
+ * Source file: storage/app/public/empodat_suspect/TerraChem soil samples 2026-06-03 upload ready.xlsx
+ * Station columns: everything AFTER 'Units' and BEFORE 'mz score' (the metadata
+ * block boundary), MINUS any 'Blank ...' filler column. Expected: 54 stations.
+ *
+ * Differs from BlackSea SEDIMENT only in the Blank-column skip: TerraChem files
+ * carry 1–5 'Blank ...' columns between 'Units' and the first sample column.
+ *
+ * See: Empodat-Suspect-new-source-onboarding.md §8 (TerraChem)
+ */
+class EmpodatSuspectTerraChemSoilXlsxStationsMappingSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    protected const FILE_ID = 10015;
+
+    protected const FILE_NAME = 'TerraChem soil samples 2026-06-03 upload ready.xlsx';
+
+    /** Structural marker: station columns begin AFTER this header. */
+    protected const STATION_BLOCK_START_AFTER = 'Units';
+
+    /** Boundary marker: HRMS metadata block (mz score, isotopicfit score, ...) begins HERE. */
+    protected const METADATA_BOUNDARY = 'mz score';
+
+    public function run(): void
+    {
+        $target = 'empodat_suspect_xlsx_stations_mapping';
+        $path = storage_path('app/public/empodat_suspect/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->command->error("Source file not found: {$path}");
+
+            return;
+        }
+
+        $this->command->info('Reading xlsx headers from TerraChem SOIL (file_id='.self::FILE_ID.')...');
+
+        $firstRow = SimpleExcelReader::create($path)->getRows()->first();
+        if (! $firstRow) {
+            $this->command->error('Source file appears empty (no header row)');
+
+            return;
+        }
+
+        $header = $this->cleanHeader(array_keys($firstRow));
+        $stationCols = $this->extractStationColumns($header);
+
+        if (empty($stationCols)) {
+            $this->command->error('No station columns identified — check boundary markers');
+
+            return;
+        }
+
+        $this->command->info('Identified '.count($stationCols).' station columns (after "'.self::STATION_BLOCK_START_AFTER.'", before "'.self::METADATA_BOUNDARY.'")');
+
+        $now = Carbon::now();
+        $inserted = 0;
+        $skipped = 0;
+
+        foreach ($stationCols as $xlsxName) {
+            $exists = DB::table($target)
+                ->where('xlsx_name', $xlsxName)
+                ->where('file_id', self::FILE_ID)
+                ->exists();
+
+            if ($exists) {
+                $this->command->info("Skipping duplicate (file_id, xlsx_name): {$xlsxName}");
+                $skipped++;
+
+                continue;
+            }
+
+            DB::table($target)->insert([
+                'xlsx_name' => $xlsxName,
+                'file_id' => self::FILE_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $inserted++;
+        }
+
+        $this->command->info("Done: {$inserted} inserted, {$skipped} skipped (file_id=".self::FILE_ID.')');
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function cleanHeader(array $header): array
+    {
+        return array_map(
+            fn (string $h): string => trim(str_replace("\xEF\xBB\xBF", '', $h)),
+            $header
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<int, string>
+     */
+    protected function extractStationColumns(array $header): array
+    {
+        $startIndex = array_search(self::STATION_BLOCK_START_AFTER, $header, true);
+        if ($startIndex === false) {
+            $this->command->warn('Boundary column "'.self::STATION_BLOCK_START_AFTER.'" not found in header');
+
+            return [];
+        }
+
+        $stationCols = [];
+        $headerCount = count($header);
+
+        for ($i = $startIndex + 1; $i < $headerCount; $i++) {
+            $name = $header[$i] ?? '';
+
+            if ($name === self::METADATA_BOUNDARY) {
+                break;
+            }
+
+            if ($name === '' || $name === null) {
+                continue;
+            }
+
+            if (stripos($name, 'Blank') === 0) {
+                continue;
+            }
+
+            $stationCols[] = $name;
+        }
+
+        return $stationCols;
+    }
+}
+// php artisan db:seed --class=Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectTerraChemSoilXlsxStationsMappingSeeder


### PR DESCRIPTION
Adds the four TerraChem suspect-screening sources, cloned from the proven BlackSea SEDIMENT 5-class seeder pattern.

## Sources (20 new seeder classes, 5 per source)

| File ID | Source | Sample cols | main+metadata rows | substances |
|---:|---|---:|---:|---:|
| 10012 | Invertebrate | 83 | 7,946,089 | 95,051 |
| 10013 | Plant | 71 | 6,602,929 | 92,315 |
| 10014 | Rodent | 162 | 15,509,556 | 95,051 |
| 10015 | Soil | 54 | 5,169,852 | 95,051 |

Verified on the local dev DB: **35,228,426** main+metadata rows, **370** station mappings, **0 unresolved**. Soil is the first source to populate `empodat_suspect_matrix_soil` (~154,600 rows after MV refresh).

## TerraChem deviations from the BlackSea template (each header-checked against the real files)

- **All 4:** 1–5 `Blank …` filler columns between `Units` and the first sample column are skipped (`stripos($name,'Blank')===0`).
- **All 4:** HRMS column is spelled `numberoffragments score` (with "ber"), not BlackSea's `numoffragments score` — mapped explicitly so the column isn't silently NULLed.
- **Plant only:** reads `Basedon HRMSLibrary` (with a space); stray `Unit` column ignored; `Identification_Proofs` absent (NULL).
- **Rodent:** `Identification_Proofs` absent (NULL).

## Performance

`BATCH_SIZE` 500 → 4000 and `memory_limit` 4G → 16G across all four MainSeeders. 4000 is the optimum under Postgres' 65535 bind-parameter limit (`empodat_suspect_metadata` is the widest write at 16 columns: 16 × 4000 = 64000). ~2× faster end-to-end.

## Notes

- No new migrations — `empodat_suspect_metadata` + partitions already exist from BlackSea.
- MVs are intentionally **not** refreshed in this PR; run `refresh-filters` → `refresh-prioritisation` → `refresh-matrix-metadata` after the data lands (order matters).
- Source xlsx files are gitignored; they live at `storage/app/public/empodat_suspect/` locally and must be rsynced to prod at deploy time.