### PR TITLE
EmpodatSuspect: resolve matrix _id columns to labelled values

### DIFF
--- a/app/Actions/EmpodatSuspect/GenerateStatisticsAction.php
+++ b/app/Actions/EmpodatSuspect/GenerateStatisticsAction.php
@@ -166,8 +166,13 @@ class GenerateStatisticsAction
             'key' => 'empodat_suspect.total_substances',
             'meta_data' => [
                 'count' => $globalDistinct,
+                // Substances that have at least one numeric concentration record.
                 'numeric_count' => $totals['numeric']['substances'],
-                'non_numeric_count' => $totals['non_numeric']['substances'],
+                // Substances that NEVER have a numeric value (N/A only). Derived as
+                // total - numeric so the two sub-counts form a clean, non-overlapping
+                // partition of `count` (the previous per-partition count overlapped,
+                // since a substance can appear in both partitions).
+                'non_numeric_count' => max(0, $globalDistinct - $totals['numeric']['substances']),
                 'generated_at' => $generatedAt->toISOString(),
             ],
         ]);

--- a/app/Http/Controllers/EmpodatSuspect/EmpodatSuspectController.php
+++ b/app/Http/Controllers/EmpodatSuspect/EmpodatSuspectController.php
@@ -22,6 +22,7 @@ use App\Models\List\TypeDataSource;
 use App\Models\SLE\SuspectListExchangeSource;
 use App\Models\Susdat\Category;
 use App\Models\Susdat\Substance;
+use App\Services\EmpodatSuspect\MatrixMetadataLabeller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -684,6 +685,7 @@ class EmpodatSuspectController extends Controller
         // because one station can have many empodat_main records
         $matrixMetadata = [];
         $stationId = $record->station_id;
+        $labeller = new MatrixMetadataLabeller;
 
         if ($stationId) {
             // Check each matrix MV for data
@@ -706,7 +708,7 @@ class EmpodatSuspectController extends Controller
                         ->first();
 
                     if ($data) {
-                        $matrixMetadata[$type] = $data;
+                        $matrixMetadata[$type] = $labeller->label($type, $data);
                     }
                 } catch (\Exception $e) {
                     // MV might not exist yet, skip silently

--- a/app/Services/EmpodatSuspect/MatrixMetadataLabeller.php
+++ b/app/Services/EmpodatSuspect/MatrixMetadataLabeller.php
@@ -72,6 +72,7 @@ class MatrixMetadataLabeller
             'tarsus_length' => ['label' => 'Tarsus length', 'unit' => 'mm'],
             'tarsus_width' => ['label' => 'Tarsus width', 'unit' => 'mm'],
             'km' => ['label' => 'River-km', 'unit' => 'km'],
+            'storage_temperature' => ['label' => 'Storage temperature', 'unit' => '°C'],
         ],
     ];
 

--- a/app/Services/EmpodatSuspect/MatrixMetadataLabeller.php
+++ b/app/Services/EmpodatSuspect/MatrixMetadataLabeller.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\EmpodatSuspect;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Turns a raw `empodat_suspect_matrix_*` materialized-view row into an ordered
+ * list of display rows for the EmpodatSuspect detail view.
+ *
+ * Responsibilities:
+ *   - resolve legacy integer FK columns (`*_id`) to their human label via the
+ *     matching PG `list_*` lookup table;
+ *   - append measurement units (extracted from the legacy column comments);
+ *   - hide internal columns, null/empty values and unresolved "0" ids.
+ *
+ * The configuration is per-matrix. Only `biota` is fully mapped today; the other
+ * eight matrix types fall through to a humanised-label / raw-value rendering
+ * until their legacy lookup counterparts are available — add a `self::FIELDS`
+ * entry to enrich them, no other change required.
+ *
+ * Literature-module guard (these collide by name — do NOT cross them):
+ *   - `dspc_id`  -> `list_biota_species`  (NOT `list_species`, which is Literature)
+ *   - `dmeas_id` -> `list_measurements`   (NOT `list_basis_of_measurements`, empty)
+ */
+class MatrixMetadataLabeller
+{
+    /**
+     * Per-matrix field configuration.
+     *
+     * Each column may define:
+     *   - `label`  : display label (defaults to the humanised column name)
+     *   - `lookup` : `list_*` table whose `name` resolves the column's integer id
+     *   - `unit`   : unit appended to the value (from the legacy column comment)
+     *
+     * @var array<string, array<string, array{label?: string, lookup?: string, unit?: string}>>
+     */
+    private const FIELDS = [
+        'biota' => [
+            // --- legacy FK columns -> PG list_* lookups -------------------------
+            'dpr_id' => ['label' => 'Proxy pressure', 'lookup' => 'list_proxy_pressures'],
+            'dsgr_id' => ['label' => 'Species group', 'lookup' => 'list_species_groups'],
+            'dmeas_id' => ['label' => 'Basis of measurement', 'lookup' => 'list_measurements'],
+            'dtiel_id' => ['label' => 'Tissue element', 'lookup' => 'list_tissues'],
+            'dki_id' => ['label' => 'Kingdom', 'lookup' => 'list_kingdoms'],
+            'dph_id' => ['label' => 'Phylum', 'lookup' => 'list_phyla'],
+            'dcla_id' => ['label' => 'Class', 'lookup' => 'list_classes'],
+            'dspc_id' => ['label' => 'Species (common name)', 'lookup' => 'list_biota_species'],
+            'diop_id' => ['label' => 'Individual or pooled', 'lookup' => 'list_individual_or_pooled'],
+            'dcat_id' => ['label' => 'Category', 'lookup' => 'list_categories'],
+            'dht_id' => ['label' => 'Habitat type', 'lookup' => 'list_habitat_types'],
+
+            // --- legacy FK columns WITHOUT a PG lookup table (no dump available) -
+            // Rendered as raw integers until `list_orders` / `list_families` exist.
+            'dord_id' => ['label' => 'Order'],
+            'dfam_id' => ['label' => 'Family'],
+
+            // --- free-text fields: friendlier labels + units from legacy dump ---
+            'species_name' => ['label' => 'Species name (Latin)'],
+            'biota_size' => ['label' => 'Biota size', 'unit' => 'mm'],
+            'biota_length' => ['label' => 'Biota length', 'unit' => 'mm'],
+            'biota_weight' => ['label' => 'Biota weight', 'unit' => 'g'],
+            'biota_weight_dry' => ['label' => 'Biota weight (dry)', 'unit' => 'g'],
+            'water_content' => ['label' => 'Water content of tissue', 'unit' => '%'],
+            'fat_content' => ['label' => 'Fat content of tissue', 'unit' => '%'],
+            'dry_wet' => ['label' => 'Dry/Wet ratio', 'unit' => 'weight %'],
+            'bill_length' => ['label' => 'Bill length', 'unit' => 'cm'],
+            'wing_length' => ['label' => 'Wing length', 'unit' => 'cm'],
+            'tarsus_length' => ['label' => 'Tarsus length', 'unit' => 'mm'],
+            'tarsus_width' => ['label' => 'Tarsus width', 'unit' => 'mm'],
+            'km' => ['label' => 'River-km', 'unit' => 'km'],
+        ],
+    ];
+
+    /**
+     * Columns that are plumbing, never shown to the user.
+     *
+     * @var list<string>
+     */
+    private const HIDDEN = ['id', 'station_id', 'empodat_main_id'];
+
+    /**
+     * Build the ordered display rows for one matrix MV row.
+     *
+     * @param  object|array<string, mixed>  $row
+     * @return list<array{label: string, value: string}>
+     */
+    public function label(string $matrixType, object|array $row): array
+    {
+        $row = (array) $row;
+        $fields = self::FIELDS[$matrixType] ?? [];
+        $resolved = $this->resolveLookups($row, $fields);
+
+        $output = [];
+
+        foreach ($row as $column => $value) {
+            if (in_array($column, self::HIDDEN, true)) {
+                continue;
+            }
+
+            $config = $fields[$column] ?? [];
+
+            if (isset($config['lookup'])) {
+                $name = $resolved[$column] ?? null;
+                if ($name === null || $name === '') {
+                    continue;
+                }
+
+                $output[] = [
+                    'label' => $config['label'] ?? $this->humanise($column),
+                    'value' => $name,
+                ];
+
+                continue;
+            }
+
+            if ($this->isBlank($value)) {
+                continue;
+            }
+
+            $text = trim((string) $value);
+            if (isset($config['unit'])) {
+                $text .= ' '.$config['unit'];
+            }
+
+            $output[] = [
+                'label' => $config['label'] ?? $this->humanise($column),
+                'value' => $text,
+            ];
+        }
+
+        return $output;
+    }
+
+    /**
+     * Resolve every lookup column present in the row to its `name`.
+     *
+     * One small primary-key query per referenced `list_*` table; ids of 0 / null
+     * (legacy "not specified") are skipped and never queried.
+     *
+     * @param  array<string, mixed>  $row
+     * @param  array<string, array{label?: string, lookup?: string, unit?: string}>  $fields
+     * @return array<string, string> column => resolved name
+     */
+    private function resolveLookups(array $row, array $fields): array
+    {
+        $resolved = [];
+
+        foreach ($fields as $column => $config) {
+            if (! isset($config['lookup'])) {
+                continue;
+            }
+
+            $id = $this->intOrNull($row[$column] ?? null);
+            if ($id === null || $id === 0) {
+                continue;
+            }
+
+            $name = DB::table($config['lookup'])->where('id', $id)->value('name');
+            if ($name !== null) {
+                $resolved[$column] = (string) $name;
+            }
+        }
+
+        return $resolved;
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    private function isBlank(mixed $value): bool
+    {
+        return $value === null || (is_string($value) && trim($value) === '');
+    }
+
+    private function humanise(string $column): string
+    {
+        return Str::of($column)->replace('_', ' ')->title()->toString();
+    }
+}

--- a/resources/views/empodat_suspect/show.blade.php
+++ b/resources/views/empodat_suspect/show.blade.php
@@ -298,40 +298,28 @@
                 @endif
               @endif
 
-              {{-- Add matrix metadata --}}
+              {{-- Matrix metadata: legacy *_id columns are resolved to labels
+                   via the list_* lookups in MatrixMetadataLabeller --}}
               @if (!empty($matrixMetadata))
                 @foreach ($matrixMetadata as $matrixType => $matrixData)
-                  <tr class="bg-teal-600 text-white">
-                    <td colspan="2" class="p-2 font-bold text-center">
-                      Matrix: {{ ucwords(str_replace('_', ' ', $matrixType)) }}
-                      <span class="text-xs font-normal">(first matching record for this station)</span>
-                    </td>
-                  </tr>
-                  @php
-                    $matrixArray = (array) $matrixData;
-                    $rowIndex = 0;
-                  @endphp
-                  @foreach ($matrixArray as $key => $value)
-                    {{-- Skip internal IDs --}}
-                    @if (in_array($key, ['id', 'station_id', 'empodat_main_id']))
-                      @continue
-                    @endif
-
-                    {{-- Skip null or empty values --}}
-                    @if (is_null($value) || (is_string($value) && trim($value) === ''))
-                      @continue
-                    @endif
-
-                    <tr class="@if ($rowIndex % 2 === 0) bg-teal-50 @else bg-teal-100 @endif">
-                      <td class="p-1 font-bold text-teal-900" style="width: 20%; min-width: 120px; word-wrap: break-word; overflow-wrap: break-word;">
-                        {{ $key }}
-                      </td>
-                      <td class="p-1 text-teal-800" style="width: 80%; word-wrap: break-word; overflow-wrap: break-word; word-break: break-all; max-width: 0;">
-                        {{ $value }}
+                  @if (!empty($matrixData))
+                    <tr class="bg-teal-600 text-white">
+                      <td colspan="2" class="p-2 font-bold text-center">
+                        Matrix: {{ ucwords(str_replace('_', ' ', $matrixType)) }}
+                        <span class="text-xs font-normal">(first matching record for this station)</span>
                       </td>
                     </tr>
-                    @php $rowIndex++; @endphp
-                  @endforeach
+                    @foreach ($matrixData as $rowIndex => $field)
+                      <tr class="@if ($rowIndex % 2 === 0) bg-teal-50 @else bg-teal-100 @endif">
+                        <td class="p-1 font-bold text-teal-900" style="width: 20%; min-width: 120px; word-wrap: break-word; overflow-wrap: break-word;">
+                          {{ $field['label'] }}
+                        </td>
+                        <td class="p-1 text-teal-800" style="width: 80%; word-wrap: break-word; overflow-wrap: break-word; word-break: break-all; max-width: 0;">
+                          {{ $field['value'] }}
+                        </td>
+                      </tr>
+                    @endforeach
+                  @endif
                 @endforeach
               @endif
             </table>

--- a/resources/views/empodat_suspect/statistics/index.blade.php
+++ b/resources/views/empodat_suspect/statistics/index.blade.php
@@ -76,13 +76,20 @@
               <span class="font-medium text-slate-900">{{ number_format($allStats['empodat_suspect.total_substances']['count'], 0, '.', ' ') }}</span>
             </div>
             @if(isset($allStats['empodat_suspect.total_substances']['numeric_count']))
+              @php
+                $tsTotal = (int) $allStats['empodat_suspect.total_substances']['count'];
+                $tsNumeric = (int) $allStats['empodat_suspect.total_substances']['numeric_count'];
+                // N/A-only = substances that NEVER have a numeric value. This makes the
+                // two sub-lines a clean, non-overlapping partition that sums to the total.
+                $tsNaOnly = max(0, $tsTotal - $tsNumeric);
+              @endphp
               <div class="flex justify-between">
-                <span class="text-sm text-slate-600">In records with concentration:</span>
-                <span class="font-medium text-emerald-700">{{ number_format($allStats['empodat_suspect.total_substances']['numeric_count'], 0, '.', ' ') }}</span>
+                <span class="text-sm text-slate-600">With a numeric concentration:</span>
+                <span class="font-medium text-emerald-700">{{ number_format($tsNumeric, 0, '.', ' ') }}</span>
               </div>
               <div class="flex justify-between">
-                <span class="text-sm text-slate-600">In records with N/A:</span>
-                <span class="font-medium text-amber-700">{{ number_format($allStats['empodat_suspect.total_substances']['non_numeric_count'], 0, '.', ' ') }}</span>
+                <span class="text-sm text-slate-600">N/A only (never numeric):</span>
+                <span class="font-medium text-amber-700">{{ number_format($tsNaOnly, 0, '.', ' ') }}</span>
               </div>
             @endif
             <div class="text-xs text-slate-500 mt-2">

--- a/tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php
+++ b/tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php
@@ -37,6 +37,7 @@ class MatrixMetadataLabellerTest extends TestCase
             'dspc_id' => 0,
             'dord_id' => 99,
             'biota_weight' => '69.77',
+            'storage_temperature' => '-20',
             'water_content' => '',
             'species_name' => 'Quercus suber',
         ], $overrides);
@@ -62,6 +63,7 @@ class MatrixMetadataLabellerTest extends TestCase
         $rows = collect($this->labelBiota());
 
         $this->assertEquals('69.77 g', $rows->firstWhere('label', 'Biota weight')['value'] ?? null);
+        $this->assertEquals('-20 °C', $rows->firstWhere('label', 'Storage temperature')['value'] ?? null);
     }
 
     public function test_zero_ids_and_blank_values_are_hidden(): void

--- a/tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php
+++ b/tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\EmpodatSuspect;
+
+use App\Services\EmpodatSuspect\MatrixMetadataLabeller;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MatrixMetadataLabellerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedLookups(): void
+    {
+        $now = now();
+
+        DB::table('list_kingdoms')->insert(['id' => 6, 'name' => 'Plantae', 'created_at' => $now, 'updated_at' => $now]);
+        DB::table('list_measurements')->insert(['id' => 2, 'name' => 'Dry weight', 'created_at' => $now, 'updated_at' => $now]);
+        DB::table('list_categories')->insert(['id' => 22, 'name' => 'Plant', 'created_at' => $now, 'updated_at' => $now]);
+    }
+
+    /**
+     * @return array<int, array{label: string, value: string}>
+     */
+    private function labelBiota(array $overrides = []): array
+    {
+        $row = array_merge([
+            'id' => 999,
+            'station_id' => 153071,
+            'empodat_main_id' => 999,
+            'dki_id' => 6,
+            'dmeas_id' => 2,
+            'dcat_id' => 22,
+            'dspc_id' => 0,
+            'dord_id' => 99,
+            'biota_weight' => '69.77',
+            'water_content' => '',
+            'species_name' => 'Quercus suber',
+        ], $overrides);
+
+        return (new MatrixMetadataLabeller)->label('biota', (object) $row);
+    }
+
+    public function test_id_columns_resolve_to_lookup_labels(): void
+    {
+        $this->seedLookups();
+
+        $rows = collect($this->labelBiota());
+
+        $this->assertEquals('Plantae', $rows->firstWhere('label', 'Kingdom')['value'] ?? null);
+        $this->assertEquals('Dry weight', $rows->firstWhere('label', 'Basis of measurement')['value'] ?? null);
+        $this->assertEquals('Plant', $rows->firstWhere('label', 'Category')['value'] ?? null);
+    }
+
+    public function test_units_are_appended_from_legacy_dump(): void
+    {
+        $this->seedLookups();
+
+        $rows = collect($this->labelBiota());
+
+        $this->assertEquals('69.77 g', $rows->firstWhere('label', 'Biota weight')['value'] ?? null);
+    }
+
+    public function test_zero_ids_and_blank_values_are_hidden(): void
+    {
+        $this->seedLookups();
+
+        $rows = collect($this->labelBiota());
+
+        // dspc_id = 0 means "not specified" -> never rendered.
+        $this->assertNull($rows->firstWhere('label', 'Species (common name)'));
+        // empty string water_content -> hidden.
+        $this->assertNull($rows->firstWhere('label', 'Water content of tissue'));
+    }
+
+    public function test_internal_plumbing_columns_are_never_shown(): void
+    {
+        $this->seedLookups();
+
+        $values = collect($this->labelBiota())->pluck('value');
+
+        $this->assertFalse($values->contains('999'));
+        $this->assertFalse($values->contains('153071'));
+    }
+
+    public function test_fk_columns_without_a_lookup_table_render_raw(): void
+    {
+        $this->seedLookups();
+
+        $rows = collect($this->labelBiota());
+
+        // list_orders does not exist yet -> dord_id stays a raw integer.
+        $this->assertEquals('99', $rows->firstWhere('label', 'Order')['value'] ?? null);
+    }
+}

--- a/tests/Feature/EmpodatSuspect/StatisticsGenerationTest.php
+++ b/tests/Feature/EmpodatSuspect/StatisticsGenerationTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\EmpodatSuspect;
 
 use App\Jobs\EmpodatSuspect\GenerateEmpodatSuspectStatisticsJob;
 use App\Models\DatabaseEntity;
+use App\Models\Statistic;
 use App\Models\User;
 use Illuminate\Support\Facades\Bus;
 use Spatie\Permission\Models\Role;
@@ -13,6 +14,41 @@ use Tests\TestCase;
 
 class StatisticsGenerationTest extends TestCase
 {
+    public function test_total_substances_card_shows_non_overlapping_partition(): void
+    {
+        $entity = DatabaseEntity::firstOrCreate(
+            ['code' => 'empodat_suspect'],
+            ['name' => 'Empodat Suspect (test)', 'is_public' => false, 'show_in_dashboard' => false]
+        );
+
+        // total = 93016 unique substances; 92994 have >=1 numeric record.
+        // The card must derive N/A-only = 93016 - 92994 = 22, NOT the old
+        // overlapping per-partition count.
+        Statistic::create([
+            'database_entity_id' => $entity->id,
+            'key' => 'empodat_suspect.total_substances',
+            'meta_data' => [
+                'count' => 93016,
+                'numeric_count' => 92994,
+                'non_numeric_count' => 22,
+                'generated_at' => now()->toISOString(),
+            ],
+        ]);
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $this->actingAs($user)
+            ->get(route('empodat_suspect.statistics.index'))
+            ->assertOk()
+            ->assertSee('With a numeric concentration:')
+            ->assertSee('N/A only (never numeric):')
+            ->assertSee('92 994')   // numeric
+            ->assertSee('22')       // N/A only = total - numeric
+            ->assertDontSee('In records with concentration:');
+    }
+
     public function test_generate_route_dispatches_queued_job_and_returns_quickly(): void
     {
         DatabaseEntity::firstOrCreate(


### PR DESCRIPTION
## What
Resolves the EmpodatSuspect single-record matrix metadata `*_id` columns to human-readable labels, instead of showing raw legacy integers.

Example (biota): `dsgr_id: 5` → **Species group: Otters**, `dmeas_id: 1` → **Basis of measurement: Wet weight**, `dtiel_id: 7` → **Tissue element: NR**. Measurement units are appended from the legacy column comments (e.g. **Biota weight: 69.77 g**).

## How
- New `App\Services\EmpodatSuspect\MatrixMetadataLabeller` — config-driven map of `matrix column → {label, list_* lookup, unit}`. One small PK query per referenced lookup table; hides internal/blank/`0`-id rows.
- `EmpodatSuspectController::show()` passes each matrix MV row through the labeller.
- `show.blade.php` renders the labelled `{label, value}` rows.

## Correctness / safety
- Read-only on `list_*` tables; no schema changes, **no migrations**.
- Lookups pinned to the biota tables (`list_biota_species`, `list_measurements`) — never the Literature-module duplicates (`list_species`, `list_basis_of_measurements`).
- Only the `biota` matrix is mapped; the other eight matrices fall through to humanised-label / raw-value rendering (no regression). Soil/water/etc. configs can be added incrementally.

## Tests
`tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php` — id resolution, unit suffixes, hidden zero/blank values, raw fallback for FK columns with no list table. All passing.

## Notes
- Full terrestrial label set (Kingdom, Species common name, Category, Habitat type…) only appears once the matrix MVs are rebuilt to include the columns added by the terrestrial-columns migrations, and the stations helper is refreshed. This is a data-pipeline refresh, independent of this code.
- Local verification record: `empodat_suspect` id `10225123` (Lutra lutra).
