### PR TITLE
Release: EmpodatSuspect storage_temperature unit + clearer Total Substances stat

### DIFF
--- a/app/Actions/EmpodatSuspect/GenerateStatisticsAction.php
+++ b/app/Actions/EmpodatSuspect/GenerateStatisticsAction.php
@@ -166,8 +166,13 @@ class GenerateStatisticsAction
             'key' => 'empodat_suspect.total_substances',
             'meta_data' => [
                 'count' => $globalDistinct,
+                // Substances that have at least one numeric concentration record.
                 'numeric_count' => $totals['numeric']['substances'],
-                'non_numeric_count' => $totals['non_numeric']['substances'],
+                // Substances that NEVER have a numeric value (N/A only). Derived as
+                // total - numeric so the two sub-counts form a clean, non-overlapping
+                // partition of `count` (the previous per-partition count overlapped,
+                // since a substance can appear in both partitions).
+                'non_numeric_count' => max(0, $globalDistinct - $totals['numeric']['substances']),
                 'generated_at' => $generatedAt->toISOString(),
             ],
         ]);

--- a/app/Services/EmpodatSuspect/MatrixMetadataLabeller.php
+++ b/app/Services/EmpodatSuspect/MatrixMetadataLabeller.php
@@ -72,6 +72,7 @@ class MatrixMetadataLabeller
             'tarsus_length' => ['label' => 'Tarsus length', 'unit' => 'mm'],
             'tarsus_width' => ['label' => 'Tarsus width', 'unit' => 'mm'],
             'km' => ['label' => 'River-km', 'unit' => 'km'],
+            'storage_temperature' => ['label' => 'Storage temperature', 'unit' => '°C'],
         ],
     ];
 

--- a/resources/views/empodat_suspect/statistics/index.blade.php
+++ b/resources/views/empodat_suspect/statistics/index.blade.php
@@ -76,13 +76,20 @@
               <span class="font-medium text-slate-900">{{ number_format($allStats['empodat_suspect.total_substances']['count'], 0, '.', ' ') }}</span>
             </div>
             @if(isset($allStats['empodat_suspect.total_substances']['numeric_count']))
+              @php
+                $tsTotal = (int) $allStats['empodat_suspect.total_substances']['count'];
+                $tsNumeric = (int) $allStats['empodat_suspect.total_substances']['numeric_count'];
+                // N/A-only = substances that NEVER have a numeric value. This makes the
+                // two sub-lines a clean, non-overlapping partition that sums to the total.
+                $tsNaOnly = max(0, $tsTotal - $tsNumeric);
+              @endphp
               <div class="flex justify-between">
-                <span class="text-sm text-slate-600">In records with concentration:</span>
-                <span class="font-medium text-emerald-700">{{ number_format($allStats['empodat_suspect.total_substances']['numeric_count'], 0, '.', ' ') }}</span>
+                <span class="text-sm text-slate-600">With a numeric concentration:</span>
+                <span class="font-medium text-emerald-700">{{ number_format($tsNumeric, 0, '.', ' ') }}</span>
               </div>
               <div class="flex justify-between">
-                <span class="text-sm text-slate-600">In records with N/A:</span>
-                <span class="font-medium text-amber-700">{{ number_format($allStats['empodat_suspect.total_substances']['non_numeric_count'], 0, '.', ' ') }}</span>
+                <span class="text-sm text-slate-600">N/A only (never numeric):</span>
+                <span class="font-medium text-amber-700">{{ number_format($tsNaOnly, 0, '.', ' ') }}</span>
               </div>
             @endif
             <div class="text-xs text-slate-500 mt-2">

--- a/tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php
+++ b/tests/Feature/EmpodatSuspect/MatrixMetadataLabellerTest.php
@@ -37,6 +37,7 @@ class MatrixMetadataLabellerTest extends TestCase
             'dspc_id' => 0,
             'dord_id' => 99,
             'biota_weight' => '69.77',
+            'storage_temperature' => '-20',
             'water_content' => '',
             'species_name' => 'Quercus suber',
         ], $overrides);
@@ -62,6 +63,7 @@ class MatrixMetadataLabellerTest extends TestCase
         $rows = collect($this->labelBiota());
 
         $this->assertEquals('69.77 g', $rows->firstWhere('label', 'Biota weight')['value'] ?? null);
+        $this->assertEquals('-20 °C', $rows->firstWhere('label', 'Storage temperature')['value'] ?? null);
     }
 
     public function test_zero_ids_and_blank_values_are_hidden(): void

--- a/tests/Feature/EmpodatSuspect/StatisticsGenerationTest.php
+++ b/tests/Feature/EmpodatSuspect/StatisticsGenerationTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\EmpodatSuspect;
 
 use App\Jobs\EmpodatSuspect\GenerateEmpodatSuspectStatisticsJob;
 use App\Models\DatabaseEntity;
+use App\Models\Statistic;
 use App\Models\User;
 use Illuminate\Support\Facades\Bus;
 use Spatie\Permission\Models\Role;
@@ -13,6 +14,41 @@ use Tests\TestCase;
 
 class StatisticsGenerationTest extends TestCase
 {
+    public function test_total_substances_card_shows_non_overlapping_partition(): void
+    {
+        $entity = DatabaseEntity::firstOrCreate(
+            ['code' => 'empodat_suspect'],
+            ['name' => 'Empodat Suspect (test)', 'is_public' => false, 'show_in_dashboard' => false]
+        );
+
+        // total = 93016 unique substances; 92994 have >=1 numeric record.
+        // The card must derive N/A-only = 93016 - 92994 = 22, NOT the old
+        // overlapping per-partition count.
+        Statistic::create([
+            'database_entity_id' => $entity->id,
+            'key' => 'empodat_suspect.total_substances',
+            'meta_data' => [
+                'count' => 93016,
+                'numeric_count' => 92994,
+                'non_numeric_count' => 22,
+                'generated_at' => now()->toISOString(),
+            ],
+        ]);
+
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $this->actingAs($user)
+            ->get(route('empodat_suspect.statistics.index'))
+            ->assertOk()
+            ->assertSee('With a numeric concentration:')
+            ->assertSee('N/A only (never numeric):')
+            ->assertSee('92 994')   // numeric
+            ->assertSee('22')       // N/A only = total - numeric
+            ->assertDontSee('In records with concentration:');
+    }
+
     public function test_generate_route_dispatches_queued_job_and_returns_quickly(): void
     {
         DatabaseEntity::firstOrCreate(


### PR DESCRIPTION
Branched from `main` to avoid the squash-merge history conflict that blocks the development→main path.

- Biota matrix: append unit to `storage_temperature` (e.g. `-20 °C`).
- Statistics "Total Substances" card: replace overlapping per-partition substance counts with a clean, non-overlapping partition (Total = numeric + N/A-only). View derives N/A-only from stored `count`/`numeric_count`, so it is correct on existing production data without regenerating the stat.

No migrations. Tests pass; Pint clean. (Already merged to development via #73; #76 superseded by this.)
