### PR TITLE
EmpodatSuspect: sortable result columns (filter-gated heavy sorts)

### DIFF
--- a/app/Http/Controllers/EmpodatSuspect/EmpodatSuspectController.php
+++ b/app/Http/Controllers/EmpodatSuspect/EmpodatSuspectController.php
@@ -368,6 +368,11 @@ class EmpodatSuspectController extends Controller
             // Log query if not paginated request
             $queryLogId = $this->logQuery($empodatSuspects, $mainRequest, $request);
 
+            // Apply user-selected sorting (after logging so the query hash stays
+            // stable across sort changes). Relationship-backed sorts are only
+            // allowed once filters have narrowed the result set.
+            $this->applySorting($empodatSuspects, $request, $hasFilters);
+
             // Apply pagination
             $empodatSuspects = $this->applyPagination($empodatSuspects, $request);
 
@@ -595,17 +600,102 @@ class EmpodatSuspectController extends Controller
     }
 
     /**
-     * Apply pagination based on display option
+     * Apply pagination based on display option.
+     *
+     * Ordering is applied separately by applySorting() before this runs.
      */
     private function applyPagination($query, Request $request)
     {
-        $orderBy = $query->orderBy('empodat_suspect_main.id', 'asc');
-
         if ($request->input('displayOption') == 1) {
-            return $orderBy->simplePaginate(200)->withQueryString();
-        } else {
-            return $orderBy->paginate(200)->withQueryString();
+            return $query->simplePaginate(200)->withQueryString();
         }
+
+        return $query->paginate(200)->withQueryString();
+    }
+
+    /**
+     * Columns that sort against the partitioned empodat_suspect_main table
+     * directly (no join). These are always available, even on unfiltered
+     * searches.
+     *
+     * @var array<string, string>
+     */
+    private const DIRECT_SORT_COLUMNS = [
+        'id' => 'empodat_suspect_main.id',
+        'concentration' => 'empodat_suspect_main.concentration',
+        'units' => 'empodat_suspect_main.units',
+        'ip_max' => 'empodat_suspect_main.ip_max',
+        'hrms' => 'empodat_suspect_main.based_on_hrms_library',
+    ];
+
+    /**
+     * Columns that require a join or a correlated sub-select to sort. Sorting
+     * these over the full (unfiltered) result set scans millions of rows, so
+     * they are only honoured once the user has applied at least one filter.
+     *
+     * @var array<string, string>
+     */
+    private const RELATED_SORT_COLUMNS = [
+        'substance' => 'susdat_substances.name',
+        'country' => 'list_countries.name',
+        'sample_code' => 'empodat_stations.short_sample_code',
+        'station' => 'empodat_stations.name',
+        'year' => 'sampling_year',
+    ];
+
+    /**
+     * Apply a whitelisted ORDER BY to the results query.
+     *
+     * Only columns in the two maps above may be sorted — this prevents SQL
+     * injection and keeps sorts to columns we can serve. Relationship-backed
+     * sorts are gated behind $hasFilters so an unfiltered search can never
+     * trigger a multi-million-row join sort.
+     */
+    private function applySorting($query, Request $request, bool $hasFilters): void
+    {
+        $sort = (string) $request->input('sort', 'id');
+        $direction = strtolower((string) $request->input('direction', 'asc')) === 'desc' ? 'desc' : 'asc';
+
+        if (array_key_exists($sort, self::DIRECT_SORT_COLUMNS)) {
+            $query->orderBy(self::DIRECT_SORT_COLUMNS[$sort], $direction);
+        } elseif ($hasFilters && array_key_exists($sort, self::RELATED_SORT_COLUMNS)) {
+            $this->joinForSort($query, $sort);
+
+            if ($sort === 'year') {
+                // Order by the correlated sub-select alias added in search().
+                $query->orderByRaw('sampling_year '.$direction.' nulls last');
+            } else {
+                $query->orderBy(self::RELATED_SORT_COLUMNS[$sort], $direction);
+            }
+        } else {
+            // Unknown column, or a related column requested without filters:
+            // fall back to the default stable order and stop.
+            $query->orderBy('empodat_suspect_main.id', 'asc');
+
+            return;
+        }
+
+        // Deterministic tiebreaker so pagination is stable for low-cardinality
+        // sorts (units, hrms, year, ...).
+        if ($sort !== 'id') {
+            $query->orderBy('empodat_suspect_main.id', 'asc');
+        }
+    }
+
+    /**
+     * Add the join(s) a relationship-backed sort column needs. `year` needs no
+     * join (it uses the correlated sub-select aliased in search()).
+     */
+    private function joinForSort($query, string $sort): void
+    {
+        match ($sort) {
+            'substance' => $query->leftJoin('susdat_substances', 'susdat_substances.id', '=', 'empodat_suspect_main.substance_id'),
+            'sample_code', 'station' => $query->leftJoin('empodat_stations', 'empodat_stations.id', '=', 'empodat_suspect_main.station_id'),
+            'country' => $query
+                ->leftJoin('empodat_stations', 'empodat_stations.id', '=', 'empodat_suspect_main.station_id')
+                ->leftJoin('list_countries', 'list_countries.id', '=', 'empodat_stations.country_id'),
+            default => null,
+        };
     }
 
     /**

--- a/resources/views/empodat_suspect/index.blade.php
+++ b/resources/views/empodat_suspect/index.blade.php
@@ -208,19 +208,64 @@
             @endif
           </div>
 
+          {{-- Sorting legend --}}
+          <div class="mb-2 text-xs text-gray-600 flex items-start gap-2">
+            <i class="fas fa-info-circle text-gray-400 mt-0.5"></i>
+            <span>
+              <strong>Sorting</strong> reorders <em>all</em> matching records, so it can take a while on broad searches —
+              the more filters you apply, the faster it gets.
+              The columns marked <i class="fas fa-lock text-[10px] opacity-60"></i>
+              (<span class="text-amber-700">Substance, Country, Year, Sample Code, Sampling Station</span>)
+              can only be sorted after you apply a filter, and are the slowest.
+            </span>
+          </div>
+
           <table class="table-standard">
             <thead>
+              @php
+                // Keep these in sync with EmpodatSuspectController DIRECT/RELATED_SORT_COLUMNS.
+                $directSortCols = ['id', 'concentration', 'units', 'ip_max', 'hrms'];
+                $relatedSortCols = ['substance', 'country', 'sample_code', 'station', 'year'];
+                $columnLabels = [
+                    'id' => 'ID',
+                    'substance' => 'Substance',
+                    'concentration' => 'Concentration',
+                    'units' => 'Units',
+                    'ip_max' => 'IP_max',
+                    'hrms' => 'HRMS Library',
+                    'country' => 'Country',
+                    'year' => 'Year',
+                    'sample_code' => 'Sample Code',
+                    'station' => 'Sampling Station',
+                ];
+                $currentSort = request('sort', 'id');
+                $currentDir = strtolower(request('direction', 'asc')) === 'desc' ? 'desc' : 'asc';
+              @endphp
               <tr class="bg-gray-600 text-white">
-                <th>ID</th>
-                <th>Substance</th>
-                <th>Concentration</th>
-                <th>Units</th>
-                <th>IP_max</th>
-                <th>HRMS Library</th>
-                <th>Country</th>
-                <th>Year</th>
-                <th>Sample Code</th>
-                <th>Sampling Station</th>
+                @foreach ($columnLabels as $key => $label)
+                  @php
+                    $isSortable = in_array($key, $directSortCols, true)
+                        || ($hasFilters && in_array($key, $relatedSortCols, true));
+                    $isActive = $isSortable && $currentSort === $key;
+                    $nextDir = ($isActive && $currentDir === 'asc') ? 'desc' : 'asc';
+                    $icon = $isActive
+                        ? ($currentDir === 'asc' ? 'fa-sort-up' : 'fa-sort-down')
+                        : ($isSortable ? 'fa-sort' : 'fa-lock');
+                  @endphp
+                  <th class="whitespace-nowrap">
+                    @if ($isSortable)
+                      <a href="{{ request()->fullUrlWithQuery(['sort' => $key, 'direction' => $nextDir, 'page' => 1]) }}"
+                         class="inline-flex items-center gap-1 hover:underline {{ $isActive ? 'font-bold' : '' }}">
+                        {{ $label }}<i class="fas {{ $icon }} text-xs {{ $isActive ? '' : 'opacity-50' }}"></i>
+                      </a>
+                    @else
+                      <span class="inline-flex items-center gap-1 cursor-help"
+                            title="Apply at least one filter to sort by this column">
+                        {{ $label }}<i class="fas {{ $icon }} text-xs opacity-40"></i>
+                      </span>
+                    @endif
+                  </th>
+                @endforeach
               </tr>
             </thead>
             <tbody>

--- a/tests/Feature/EmpodatSuspect/EmpodatSuspectSortingTest.php
+++ b/tests/Feature/EmpodatSuspect/EmpodatSuspectSortingTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\EmpodatSuspect;
+
+use App\Models\DatabaseEntity;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class EmpodatSuspectSortingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function authUser(): User
+    {
+        DatabaseEntity::firstOrCreate(
+            ['code' => 'empodat_suspect'],
+            ['name' => 'Empodat Suspect (test)', 'is_public' => false, 'show_in_dashboard' => false]
+        );
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        return $user;
+    }
+
+    /**
+     * Three numeric rows; ip_max is intentionally out of id order so the two
+     * orderings are distinguishable: id 1,2,3 -> ip_max 0.20, 0.90, 0.55.
+     */
+    private function seedRows(): void
+    {
+        // Referenced rows for the substance_id / station_id foreign keys.
+        DB::table('susdat_substances')->insert(['id' => 1, 'name' => 'Test Substance']);
+        DB::table('empodat_stations')->insert(['id' => 1, 'name' => 'Test Station', 'short_sample_code' => 'TS-1']);
+
+        foreach ([[1, 0.20], [2, 0.90], [3, 0.55]] as [$id, $ipMax]) {
+            DB::table('empodat_suspect_main')->insert([
+                'id' => $id,
+                'is_numeric_concentration' => true,
+                'substance_id' => 1,
+                'station_id' => 1,
+                'concentration' => $id * 10,
+                'ip_max' => $ipMax,
+                'based_on_hrms_library' => false,
+                'units' => 'ng/L',
+            ]);
+        }
+    }
+
+    private function search(User $user, array $params)
+    {
+        return $this->actingAs($user)->get(
+            route('empodat_suspect.search.search', array_merge(['displayOption' => 1], $params))
+        );
+    }
+
+    public function test_default_order_is_by_id_ascending(): void
+    {
+        $user = $this->authUser();
+        $this->seedRows();
+
+        $this->search($user, [])
+            ->assertOk()
+            ->assertSeeInOrder(['0.20', '0.90', '0.55']); // ip_max shown in id order 1,2,3
+    }
+
+    public function test_direct_column_sort_descending(): void
+    {
+        $user = $this->authUser();
+        $this->seedRows();
+
+        $this->search($user, ['sort' => 'ip_max', 'direction' => 'desc'])
+            ->assertOk()
+            ->assertSeeInOrder(['0.90', '0.55', '0.20']);
+    }
+
+    public function test_direct_column_sort_ascending(): void
+    {
+        $user = $this->authUser();
+        $this->seedRows();
+
+        $this->search($user, ['sort' => 'ip_max', 'direction' => 'asc'])
+            ->assertOk()
+            ->assertSeeInOrder(['0.20', '0.55', '0.90']);
+    }
+
+    public function test_invalid_sort_falls_back_to_id(): void
+    {
+        $user = $this->authUser();
+        $this->seedRows();
+
+        $this->search($user, ['sort' => 'bogus; DROP TABLE x', 'direction' => 'desc'])
+            ->assertOk()
+            ->assertSeeInOrder(['0.20', '0.90', '0.55']); // id order
+    }
+
+    public function test_related_column_sort_is_ignored_without_filters(): void
+    {
+        // A relationship-backed sort (substance) must NOT run on an unfiltered
+        // search — it falls back to the default id order instead of attempting
+        // a multi-million-row join sort.
+        $user = $this->authUser();
+        $this->seedRows();
+
+        $this->search($user, ['sort' => 'substance', 'direction' => 'desc'])
+            ->assertOk()
+            ->assertSeeInOrder(['0.20', '0.90', '0.55']); // id order, not substance order
+    }
+
+    public function test_related_column_sort_runs_when_a_filter_is_applied(): void
+    {
+        // With a filter applied the join-backed sort is allowed: station name
+        // asc must put "Alpha" (id 2) before "Bravo" (id 1), i.e. opposite to id
+        // order — proving the leftJoin + ORDER BY path executes correctly.
+        $user = $this->authUser();
+        DB::table('susdat_substances')->insert(['id' => 1, 'name' => 'Test Substance']);
+        DB::table('empodat_stations')->insert([
+            ['id' => 1, 'name' => 'Bravo Station', 'short_sample_code' => 'B-1'],
+            ['id' => 2, 'name' => 'Alpha Station', 'short_sample_code' => 'A-1'],
+        ]);
+        DB::table('empodat_suspect_main')->insert([
+            ['id' => 1, 'is_numeric_concentration' => true, 'substance_id' => 1, 'station_id' => 1, 'concentration' => 10, 'ip_max' => 0.20, 'based_on_hrms_library' => false, 'units' => 'ng/L'],
+            ['id' => 2, 'is_numeric_concentration' => true, 'substance_id' => 1, 'station_id' => 2, 'concentration' => 20, 'ip_max' => 0.90, 'based_on_hrms_library' => false, 'units' => 'ng/L'],
+        ]);
+
+        // analyticalMethodSearch flips hasFilters on without constraining rows.
+        $this->actingAs($user)->get(route('empodat_suspect.search.search', [
+            'displayOption' => 1,
+            'analyticalMethodSearch' => [1],
+            'sort' => 'station',
+            'direction' => 'asc',
+        ]))
+            ->assertOk()
+            ->assertSeeInOrder(['Alpha Station', 'Bravo Station']);
+    }
+}


### PR DESCRIPTION
Adds clickable column sorting to the EmpodatSuspect search results table.

## Behavior
- **Always sortable** (direct `empodat_suspect_main` columns): ID, Concentration, Units, IP_max, HRMS Library.
- **Filter-gated** (need a join / correlated sub-select): Substance, Country, Year, Sample Code, Sampling Station — sortable only after at least one filter is applied; rendered locked (🔒) otherwise. This prevents multi-million-row join sorts on unfiltered searches.
- Click a header to sort, click again to flip asc/desc; filters, displayOption and pagination are preserved in the links.
- A short legend above the table explains that sorting reorders the whole result set (so filters make it faster) and which columns are gated/slowest.

## Safety / perf
- Sort column is whitelisted (injection-safe); unknown input falls back to `ORDER BY id`.
- Stable `id` tiebreaker for deterministic pagination.
- No migration.

## Tests
`EmpodatSuspectSortingTest` — default order, asc/desc, invalid-input fallback, gated-off without filters, and the join path with a filter applied. All passing; Pint clean.
