### PR TITLE
EmpodatSuspect: login-required download email while module is non-public

### DIFF
--- a/app/Jobs/EmpodatSuspect/EmpodatSuspectCsvExportJob.php
+++ b/app/Jobs/EmpodatSuspect/EmpodatSuspectCsvExportJob.php
@@ -7,6 +7,7 @@ namespace App\Jobs\EmpodatSuspect;
 use App\Jobs\AbstractCsvExportJob;
 use App\Mail\EmpodatSuspect\CsvExportReady;
 use App\Models\Backend\QueryLog;
+use App\Models\DatabaseEntity;
 use App\Models\EmpodatSuspect\EmpodatSuspectMain;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -419,6 +420,8 @@ class EmpodatSuspectCsvExportJob extends AbstractCsvExportJob
     /**
      * Initialize message content for email notification
      * Override to use the correct route for EmpodatSuspect downloads
+     *
+     * @return array<string, mixed>
      */
     protected function initializeMessageContent(string $filename): array
     {
@@ -426,11 +429,27 @@ class EmpodatSuspectCsvExportJob extends AbstractCsvExportJob
             'user' => $this->user->name ?? $this->user->email,
             'filename' => $filename,
             'download_link' => route('empodat_suspect.csv.download', ['filename' => $filename]),
+            'my_downloads_link' => route('export_downloads.index', ['user_id' => $this->user->id]),
+            'is_public' => $this->moduleIsPublic(),
             'total_records' => 0,
             'processing_time' => 0,
             'file_size' => '0 KB',
             'export_failed' => false,
         ];
+    }
+
+    /**
+     * Whether the EmpoDat Suspect module is currently public.
+     *
+     * While the module is non-public, downloads require an authenticated
+     * session, so the notification email must direct the user to log in and
+     * fetch the prepared file from "My Downloads" rather than offering a raw
+     * download link. This reads the same flag the access controller enforces,
+     * so the email reverts automatically once the module is made public.
+     */
+    protected function moduleIsPublic(): bool
+    {
+        return (bool) DatabaseEntity::where('code', $this->getDatabaseKey())->value('is_public');
     }
 
     /**

--- a/resources/views/emails/empodatSuspectCsvReady.blade.php
+++ b/resources/views/emails/empodatSuspectCsvReady.blade.php
@@ -31,6 +31,7 @@
     </p>
 
     @else
+    @php($isPublic = $messageContent['is_public'] ?? true)
     <!-- Success Heading -->
     <h2 style="margin-top: 0; margin-bottom: 16px; font-weight: normal; color: #2A9D8F;">
       Your Empodat Suspect CSV Export Is Ready!
@@ -38,8 +39,13 @@
 
     <!-- Intro Paragraph -->
     <p style="margin-bottom: 16px;">
+      @if($isPublic)
       We're pleased to let you know that your requested Empodat Suspect CSV export is now available.
       Click the button below to download your file:
+      @else
+      We're pleased to let you know that your requested Empodat Suspect CSV export has been prepared
+      and is waiting for you in <strong>My Downloads</strong>.
+      @endif
     </p>
 
     <!-- Export Details -->
@@ -61,6 +67,7 @@
       </p>
     </div>
 
+    @if($isPublic)
     <!-- Download Button -->
     <p style="margin-bottom: 24px;">
       <a href="{{ $messageContent['download_link'] ?? '#' }}"
@@ -73,6 +80,32 @@
     <p style="font-size: 13px; color: #666; margin-bottom: 24px;">
       Note: This download link will be available for the next 24 hours.
     </p>
+    @else
+    <!-- Login-required notice (module is currently non-public) -->
+    <div style="background-color: #fdecea; border: 2px solid #e63946; border-radius: 4px; padding: 16px; margin-bottom: 20px;">
+      <p style="margin: 0 0 8px 0; font-size: 15px; font-weight: bold; color: #b02a37;">
+        🔒 You must be logged in to download this export.
+      </p>
+      <p style="margin: 0; font-size: 14px; color: #721c24;">
+        Empodat Suspect data is not public at this time. Your file has been prepared and saved to
+        your account. Log in first, then open <strong>My Downloads</strong> to retrieve it.
+      </p>
+    </div>
+
+    <!-- My Downloads Button -->
+    <p style="margin-bottom: 12px;">
+      <a href="{{ $messageContent['my_downloads_link'] ?? '#' }}"
+         style="display: inline-block; padding: 12px 24px; background-color: #2A9D8F; color: #ffffff; text-decoration: none; border-radius: 4px; font-size: 14px;">
+        Go to My Downloads
+      </a>
+    </p>
+
+    <!-- Expiration Notice -->
+    <p style="font-size: 13px; color: #666; margin-bottom: 24px;">
+      Note: This export will be available for the next 24 hours. You will be asked to log in if you
+      are not already signed in.
+    </p>
+    @endif
     @endif
 
     <!-- Footer / Signature -->

--- a/tests/Feature/EmpodatSuspect/CsvExportReadyEmailTest.php
+++ b/tests/Feature/EmpodatSuspect/CsvExportReadyEmailTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\EmpodatSuspect;
+
+use App\Mail\EmpodatSuspect\CsvExportReady;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CsvExportReadyEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function messageContent(array $overrides = []): array
+    {
+        return array_merge([
+            'user' => 'Test User',
+            'filename' => 'empodat_suspect_export_uid_5_20260613143022.csv',
+            'download_link' => 'https://example.test/empodat_suspect/search/download/file.csv',
+            'my_downloads_link' => 'https://example.test/backend/export-downloads?user_id=5',
+            'is_public' => true,
+            'total_records' => 10,
+            'processing_time' => 1.5,
+            'file_size' => '1 KB',
+            'export_failed' => false,
+        ], $overrides);
+    }
+
+    public function test_public_export_email_shows_direct_download_button(): void
+    {
+        $rendered = (new CsvExportReady($this->messageContent(['is_public' => true])))->render();
+
+        $this->assertStringContainsString('Download CSV', $rendered);
+        $this->assertStringContainsString('search/download/file.csv', $rendered);
+        $this->assertStringNotContainsString('You must be logged in', $rendered);
+    }
+
+    public function test_non_public_export_email_requires_login_and_points_to_my_downloads(): void
+    {
+        $rendered = (new CsvExportReady($this->messageContent(['is_public' => false])))->render();
+
+        $this->assertStringContainsString('You must be logged in to download', $rendered);
+        $this->assertStringContainsString('Go to My Downloads', $rendered);
+        $this->assertStringContainsString('export-downloads?user_id=5', $rendered);
+
+        // The raw download link must NOT be offered while the module is non-public.
+        $this->assertStringNotContainsString('search/download/file.csv', $rendered);
+    }
+
+    public function test_failure_email_is_unaffected_by_public_flag(): void
+    {
+        $rendered = (new CsvExportReady($this->messageContent([
+            'export_failed' => true,
+            'error' => 'Something went wrong',
+            'is_public' => false,
+        ])))->render();
+
+        $this->assertStringContainsString('Empodat Suspect Export Processing Error', $rendered);
+        $this->assertStringContainsString('Something went wrong', $rendered);
+        $this->assertStringNotContainsString('You must be logged in', $rendered);
+    }
+}


### PR DESCRIPTION
## What

While EmpoDat Suspect data is non-public, the CSV-export-ready email now clearly tells users they must be logged in, and directs them to retrieve the prepared file from **My Downloads** instead of offering a raw download link.

## Why

The direct download route (`empodat_suspect.csv.download`) is **not** behind `auth` — anyone with the filename can fetch it. While the module is non-public this both contradicts a "you must log in" message and is a small data-exposure hole. The `export_downloads.index` ("My Downloads") route **is** auth-gated, so the email now funnels users there.

## How

- `EmpodatSuspectCsvExportJob::initializeMessageContent()` passes `is_public` (read live from `database_entities.is_public` for `empodat_suspect` — the same flag the access controller enforces) and `my_downloads_link` into the email.
- The success email branches on `is_public`:
  - **Public** → unchanged: direct **Download CSV** button.
  - **Non-public** → a prominent 🔒 login-required banner + **Go to My Downloads** button; the raw link is omitted.
  - Failure emails are untouched.

## Self-resolving

Because the flag is read live, the email reverts to the direct-download button automatically once the module is made public — no code change or redeploy needed. This branch can stay open indefinitely.

## Tests

`tests/Feature/EmpodatSuspect/CsvExportReadyEmailTest.php` — 3 passing tests (public button present; non-public banner present + raw link absent; failure email ignores the flag). Pint clean.