### PR TITLE
EmpodatSuspect: reset + ordered re-seed pipeline with storage-path & performance reconciliation

### DIFF
--- a/database/seeders/EmpodatSuspect/EmpodatSuspectApexMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectApexMainSeeder.php
@@ -42,8 +42,9 @@ class EmpodatSuspectApexMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_LIFE APEX_suspect screening results_ng g wet weight_333.csv';
+        $path = storage_path('app/public/empodat_suspect/OK_LIFE APEX_suspect screening results_ng g wet weight_333.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");
@@ -89,7 +90,8 @@ class EmpodatSuspectApexMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -129,6 +131,16 @@ class EmpodatSuspectApexMainSeeder extends Seeder
                     $skippedRows++;
 
                     continue;
+                }
+
+                $substanceNormanId = trim((string) ($data['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($data['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -177,6 +189,13 @@ class EmpodatSuspectApexMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectApexSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectApexSubstancesSeeder.php
@@ -19,7 +19,7 @@ class EmpodatSuspectApexSubstancesSeeder extends Seeder
     {
         $this->command->info('Processing LIFE APEX substances for empodat_suspect_substances table...');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_LIFE APEX_suspect screening results_ng g wet weight_333.csv';
+        $path = storage_path('app/public/empodat_suspect/OK_LIFE APEX_suspect screening results_ng g wet weight_333.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectApexXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectApexXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectApexXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/apex_data_headers.csv';
+        $path = storage_path('app/public/empodat_suspect/apex_data_headers.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBiotaMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBiotaMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectBiotaMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectBiotaMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectBiotaMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectBiotaMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBiotaSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBiotaSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectBiotaSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBiotaXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBiotaXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectBiotaXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_CONNECT 1_suspect screening results_ng g wet weight_1192 - BIOTA.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_CONNECT 1_suspect screening results_ng g wet weight_1192 - BIOTA.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaBiotaMainSeeder.php
@@ -89,7 +89,7 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
     ];
 
     /** Number of main+metadata rows per insert batch. */
-    protected const BATCH_SIZE = 500;
+    protected const BATCH_SIZE = 4000;
 
     public function run(): void
     {
@@ -112,6 +112,7 @@ class EmpodatSuspectBlackSeaBiotaMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming BlackSea BIOTA → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSedimentMainSeeder.php
@@ -64,7 +64,7 @@ class EmpodatSuspectBlackSeaSedimentMainSeeder extends Seeder
         'num_fragments',
     ];
 
-    protected const BATCH_SIZE = 500;
+    protected const BATCH_SIZE = 4000;
 
     public function run(): void
     {
@@ -86,6 +86,7 @@ class EmpodatSuspectBlackSeaSedimentMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming BlackSea SEDIMENT → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectBlackSeaSurfaceWaterMainSeeder.php
@@ -57,7 +57,7 @@ class EmpodatSuspectBlackSeaSurfaceWaterMainSeeder extends Seeder
         'num_fragments',
     ];
 
-    protected const BATCH_SIZE = 500;
+    protected const BATCH_SIZE = 4000;
 
     public function run(): void
     {
@@ -79,6 +79,7 @@ class EmpodatSuspectBlackSeaSurfaceWaterMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming BlackSea Surface Water → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2BiotaMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2BiotaMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectConnect2BiotaMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectConnect2BiotaMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectConnect2BiotaMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectConnect2BiotaMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2BiotaSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2BiotaSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectConnect2BiotaSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g wet weight_1192 - BIOTA.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2BiotaXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2BiotaXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectConnect2BiotaXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_CONNECT 2_suspect screening results_ng g wet weight_1192 - BIOTA.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_CONNECT 2_suspect screening results_ng g wet weight_1192 - BIOTA.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2SedimentsMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2SedimentsMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectConnect2SedimentsMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g dry weight_1192 - SEDIMENTS.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g dry weight_1192 - SEDIMENTS.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectConnect2SedimentsMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectConnect2SedimentsMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectConnect2SedimentsMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2SedimentsSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2SedimentsSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectConnect2SedimentsSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g dry weight_1192 - SEDIMENTS.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 2_suspect screening results_ng g dry weight_1192 - SEDIMENTS.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2SedimentsXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectConnect2SedimentsXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectConnect2SedimentsXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_CONNECT 2_suspect screening results_ng g dry weight_1192 - SEDIMENTS.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_CONNECT 2_suspect screening results_ng g dry weight_1192 - SEDIMENTS.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomBiotaMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomBiotaMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectHelcomBiotaMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g wet weight_1980 - BIOTA.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g wet weight_1980 - BIOTA.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectHelcomBiotaMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectHelcomBiotaMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectHelcomBiotaMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomBiotaSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomBiotaSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectHelcomBiotaSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g wet weight_1980 - BIOTA.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g wet weight_1980 - BIOTA.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomBiotaXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomBiotaXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectHelcomBiotaXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_HELCOM PreEMPT_suspect screening results_ng g wet weight_1980 - BIOTA.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_HELCOM PreEMPT_suspect screening results_ng g wet weight_1980 - BIOTA.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomSedimentsMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomSedimentsMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectHelcomSedimentsMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g dry weight_1980 - SEDIMENTS.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g dry weight_1980 - SEDIMENTS.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectHelcomSedimentsMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectHelcomSedimentsMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectHelcomSedimentsMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomSedimentsSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomSedimentsSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectHelcomSedimentsSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g dry weight_1980 - SEDIMENTS.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_HELCOM PreEMPT_suspect screening results_ng g dry weight_1980 - SEDIMENTS.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomSedimentsXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectHelcomSedimentsXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectHelcomSedimentsXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_HELCOM PreEMPT_suspect screening results_ng g dry weight_1980 - SEDIMENTS.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_HELCOM PreEMPT_suspect screening results_ng g dry weight_1980 - SEDIMENTS.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectManualMappingFillSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectManualMappingFillSeeder.php
@@ -23,7 +23,7 @@ class EmpodatSuspectManualMappingFillSeeder extends Seeder
     {
         $this->command->info('Filling empodat_suspect_xlsx_stations_mapping from manual CSV mapping...');
 
-        $csvPath = database_path('seeders/seeds/empodat_suspect/EMPODAT_SUSPECT-mapping-JS-20251115.csv');
+        $csvPath = storage_path('app/public/empodat_suspect/EMPODAT_SUSPECT-mapping-JS-20251115.csv');
 
         if (! file_exists($csvPath)) {
             $this->command->error("CSV file not found: {$csvPath}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectResetAndReseedSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectResetAndReseedSeeder.php
@@ -127,11 +127,11 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // ---- LEGACY SOURCES (10001–10008) -----------------------------------
         // No per-source orchestrator exists, so each chain is spelled out here:
-        //   Substances -> XlsxStationsMapping -> XlsxStationsMappingFill -> Main
+        //   XlsxStationsMapping -> XlsxStationsMappingFill -> Main
+        // (substances are now collected inside each *MainSeeder's single read pass)
 
         // File ID 10001 — CONNECT 1 SEDIMENT
         $this->call([
-            EmpodatSuspectSedimentSubstancesSeeder::class,
             EmpodatSuspectSedimentXlsxStationsMappingSeeder::class,
             EmpodatSuspectSedimentXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectSedimentMainSeeder::class,
@@ -139,7 +139,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10002 — CONNECT 1 BIOTA
         $this->call([
-            EmpodatSuspectBiotaSubstancesSeeder::class,
             EmpodatSuspectBiotaXlsxStationsMappingSeeder::class,
             EmpodatSuspectBiotaXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectBiotaMainSeeder::class,
@@ -147,7 +146,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10003 — CONNECT 2 SEDIMENTS
         $this->call([
-            EmpodatSuspectConnect2SedimentsSubstancesSeeder::class,
             EmpodatSuspectConnect2SedimentsXlsxStationsMappingSeeder::class,
             EmpodatSuspectConnect2SedimentsXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectConnect2SedimentsMainSeeder::class,
@@ -155,7 +153,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10004 — CONNECT 2 BIOTA
         $this->call([
-            EmpodatSuspectConnect2BiotaSubstancesSeeder::class,
             EmpodatSuspectConnect2BiotaXlsxStationsMappingSeeder::class,
             EmpodatSuspectConnect2BiotaXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectConnect2BiotaMainSeeder::class,
@@ -163,7 +160,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10005 — HELCOM PreEMPT SEDIMENTS
         $this->call([
-            EmpodatSuspectHelcomSedimentsSubstancesSeeder::class,
             EmpodatSuspectHelcomSedimentsXlsxStationsMappingSeeder::class,
             EmpodatSuspectHelcomSedimentsXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectHelcomSedimentsMainSeeder::class,
@@ -171,7 +167,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10006 — HELCOM PreEMPT BIOTA
         $this->call([
-            EmpodatSuspectHelcomBiotaSubstancesSeeder::class,
             EmpodatSuspectHelcomBiotaXlsxStationsMappingSeeder::class,
             EmpodatSuspectHelcomBiotaXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectHelcomBiotaMainSeeder::class,
@@ -179,7 +174,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10007 — LIFE APEX
         $this->call([
-            EmpodatSuspectApexSubstancesSeeder::class,
             EmpodatSuspectApexXlsxStationsMappingSeeder::class,
             EmpodatSuspectApexXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectApexMainSeeder::class,
@@ -187,7 +181,6 @@ class EmpodatSuspectResetAndReseedSeeder extends Seeder
 
         // File ID 10008 — UBA-HELCOM
         $this->call([
-            EmpodatSuspectUbaHelcomSubstancesSeeder::class,
             EmpodatSuspectUbaHelcomXlsxStationsMappingSeeder::class,
             EmpodatSuspectUbaHelcomXlsxStationsMappingFillSeeder::class,
             EmpodatSuspectUbaHelcomMainSeeder::class,

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectResetAndReseedSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectResetAndReseedSeeder.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\EmpodatSuspect;
+
+use Database\Seeders\EmpodatSuspectDataSourceSeeder;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Full reset + STRICTLY SEQUENTIAL re-seed of the EMPODAT Suspect module.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The 15 source files (file_id 10001–10015) were originally imported in a
+ * chaotic order, and the final TerraChem batch (10012–10015) was imported in
+ * PARALLEL. Because empodat_suspect_main.id is a single shared BIGSERIAL, the
+ * parallel runs interleaved their auto-increment ids, so the per-file id ranges
+ * (files.main_id_from / main_id_to, derived later by a rescan) overlap and are
+ * out of order. This seeder wipes the Suspect data and re-imports every source
+ * one-at-a-time in ascending file_id order, so each file ends up occupying one
+ * clean, contiguous, non-overlapping block of ids.
+ *
+ * The ORDER in which the *MainSeeder classes run is the ONLY thing that assigns
+ * the id ranges. Running them sequentially (never in parallel) is the fix.
+ *
+ * WHAT IT DOES
+ * ------------
+ *   1+2. TRUNCATEs the four per-source data tables and RESTARTs their identity
+ *        sequences, so the first re-imported main row gets id = 1:
+ *            - empodat_suspect_main       (partitioned: _numeric / _nonnumeric)
+ *            - empodat_suspect_metadata   (partitioned: _numeric / _nonnumeric)
+ *            - empodat_suspect_substances
+ *            - empodat_suspect_data_source
+ *   3.   Re-imports every source in ascending file_id order. Each source's full
+ *        chain completes before the next source begins.
+ *   4.   Re-populates empodat_suspect_data_source for every Suspect file.
+ *
+ * WHAT IT DOES *NOT* DO (run manually afterwards, per the agreed workflow)
+ * -----------------------------------------------------------------------
+ *   - It does NOT rescan files.main_id_from / main_id_to / number_of_records.
+ *     Do that via the web UI "Rescan" after verifying the import.
+ *   - It does NOT refresh any materialized view or statistics.
+ *
+ * SAFETY NOTES
+ * ------------
+ *   - SHARED / reference data is deliberately NOT touched: the `files` rows
+ *     (FileSeeders use updateOrCreate), empodat_suspect_xlsx_stations_mapping,
+ *     empodat_suspect_susdat_code_mappings and susdat_substances. The per-source
+ *     XlsxStationsMapping / MappingFill seeders are idempotent (skip-if-exists /
+ *     UPDATE), so re-running them against the kept mapping table is a safe no-op.
+ *   - TRUNCATE uses no CASCADE: the only historical inbound FK (the old
+ *     file_empodat_suspect_main pivot) was dropped when empodat_suspect_main was
+ *     recreated as a partitioned table, so no live FK references these tables.
+ *   - This is a long (multi-hour) operation. Each MainSeeder manages its own
+ *     memory limits, transaction and foreign-key handling.
+ *
+ * RUN WITH:
+ *   php artisan db:seed --class="Database\\Seeders\\EmpodatSuspect\\EmpodatSuspectResetAndReseedSeeder"
+ */
+class EmpodatSuspectResetAndReseedSeeder extends Seeder
+{
+    /**
+     * Per-source data tables wiped before re-import. Truncated in a single atomic
+     * statement, so listing order is irrelevant.
+     *
+     * @var list<string>
+     */
+    private const TABLES_TO_TRUNCATE = [
+        'empodat_suspect_main',
+        'empodat_suspect_metadata',
+        'empodat_suspect_substances',
+        'empodat_suspect_data_source',
+    ];
+
+    public function run(): void
+    {
+        $this->command->warn('==================================================================');
+        $this->command->warn(' EMPODAT SUSPECT — FULL RESET AND ORDERED RE-SEED');
+        $this->command->warn(' This DELETES every row from:');
+        foreach (self::TABLES_TO_TRUNCATE as $table) {
+            $this->command->warn('   - '.$table);
+        }
+        $this->command->warn(' then re-imports all 15 sources sequentially (file_id 10001 → 10015).');
+        $this->command->warn('==================================================================');
+
+        if (! $this->command->confirm('This is destructive and runs for hours. Proceed?', false)) {
+            $this->command->info('Aborted. No changes made.');
+
+            return;
+        }
+
+        $this->truncateSuspectData();
+        $this->reseedInOrder();
+
+        $this->command->info('');
+        $this->command->info('Re-seed complete. NEXT (manual) STEPS:');
+        $this->command->info('  1. Rescan each file in the web UI to repopulate main_id_from / main_id_to / number_of_records.');
+        $this->command->info('  2. Refresh: refresh-filters -> refresh-matrix-metadata -> refresh-prioritisation, then station_filters MV + generate-statistics.');
+    }
+
+    /**
+     * Steps 1 + 2: wipe the four per-source data tables and restart their identity
+     * sequences so the first re-imported main row gets id = 1.
+     */
+    private function truncateSuspectData(): void
+    {
+        $tables = implode(', ', self::TABLES_TO_TRUNCATE);
+
+        $this->command->info("Truncating: {$tables} (RESTART IDENTITY)...");
+        DB::statement("TRUNCATE TABLE {$tables} RESTART IDENTITY");
+        $this->command->info('Truncate complete. empodat_suspect_main.id sequence restarted at 1.');
+    }
+
+    /**
+     * Steps 3 + 4: import every source in ascending file_id order. Each source's
+     * full chain finishes before the next begins, so the *MainSeeder runs — and
+     * therefore the assigned id ranges — are strictly sequential and never overlap.
+     */
+    private function reseedInOrder(): void
+    {
+        // Create the 8 legacy `files` rows (10001–10008) up front (updateOrCreate).
+        // The 7 newer `files` rows (10009–10015) are created by their own
+        // per-source orchestrators below.
+        $this->call(EmpodatSuspectFileSeeder::class);
+
+        // ---- LEGACY SOURCES (10001–10008) -----------------------------------
+        // No per-source orchestrator exists, so each chain is spelled out here:
+        //   Substances -> XlsxStationsMapping -> XlsxStationsMappingFill -> Main
+
+        // File ID 10001 — CONNECT 1 SEDIMENT
+        $this->call([
+            EmpodatSuspectSedimentSubstancesSeeder::class,
+            EmpodatSuspectSedimentXlsxStationsMappingSeeder::class,
+            EmpodatSuspectSedimentXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectSedimentMainSeeder::class,
+        ]);
+
+        // File ID 10002 — CONNECT 1 BIOTA
+        $this->call([
+            EmpodatSuspectBiotaSubstancesSeeder::class,
+            EmpodatSuspectBiotaXlsxStationsMappingSeeder::class,
+            EmpodatSuspectBiotaXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectBiotaMainSeeder::class,
+        ]);
+
+        // File ID 10003 — CONNECT 2 SEDIMENTS
+        $this->call([
+            EmpodatSuspectConnect2SedimentsSubstancesSeeder::class,
+            EmpodatSuspectConnect2SedimentsXlsxStationsMappingSeeder::class,
+            EmpodatSuspectConnect2SedimentsXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectConnect2SedimentsMainSeeder::class,
+        ]);
+
+        // File ID 10004 — CONNECT 2 BIOTA
+        $this->call([
+            EmpodatSuspectConnect2BiotaSubstancesSeeder::class,
+            EmpodatSuspectConnect2BiotaXlsxStationsMappingSeeder::class,
+            EmpodatSuspectConnect2BiotaXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectConnect2BiotaMainSeeder::class,
+        ]);
+
+        // File ID 10005 — HELCOM PreEMPT SEDIMENTS
+        $this->call([
+            EmpodatSuspectHelcomSedimentsSubstancesSeeder::class,
+            EmpodatSuspectHelcomSedimentsXlsxStationsMappingSeeder::class,
+            EmpodatSuspectHelcomSedimentsXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectHelcomSedimentsMainSeeder::class,
+        ]);
+
+        // File ID 10006 — HELCOM PreEMPT BIOTA
+        $this->call([
+            EmpodatSuspectHelcomBiotaSubstancesSeeder::class,
+            EmpodatSuspectHelcomBiotaXlsxStationsMappingSeeder::class,
+            EmpodatSuspectHelcomBiotaXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectHelcomBiotaMainSeeder::class,
+        ]);
+
+        // File ID 10007 — LIFE APEX
+        $this->call([
+            EmpodatSuspectApexSubstancesSeeder::class,
+            EmpodatSuspectApexXlsxStationsMappingSeeder::class,
+            EmpodatSuspectApexXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectApexMainSeeder::class,
+        ]);
+
+        // File ID 10008 — UBA-HELCOM
+        $this->call([
+            EmpodatSuspectUbaHelcomSubstancesSeeder::class,
+            EmpodatSuspectUbaHelcomXlsxStationsMappingSeeder::class,
+            EmpodatSuspectUbaHelcomXlsxStationsMappingFillSeeder::class,
+            EmpodatSuspectUbaHelcomMainSeeder::class,
+        ]);
+
+        // ---- NEWER SOURCES (10009–10015) ------------------------------------
+        // Each orchestrator runs its own chain:
+        //   File -> XlsxStationsMapping -> XlsxStationsMappingFill -> Main
+
+        // File ID 10009 — BlackSea BIOTA
+        $this->call(EmpodatSuspectBlackSeaBiotaSeeder::class);
+
+        // File ID 10010 — BlackSea SEDIMENT
+        $this->call(EmpodatSuspectBlackSeaSedimentSeeder::class);
+
+        // File ID 10011 — BlackSea SURFACE WATER
+        $this->call(EmpodatSuspectBlackSeaSurfaceWaterSeeder::class);
+
+        // File ID 10012 — TerraChem INVERTEBRATE
+        $this->call(EmpodatSuspectTerraChemInvertebrateSeeder::class);
+
+        // File ID 10013 — TerraChem PLANT
+        $this->call(EmpodatSuspectTerraChemPlantSeeder::class);
+
+        // File ID 10014 — TerraChem RODENT
+        $this->call(EmpodatSuspectTerraChemRodentSeeder::class);
+
+        // File ID 10015 — TerraChem SOIL
+        $this->call(EmpodatSuspectTerraChemSoilSeeder::class);
+
+        // Re-populate data sources for every Suspect file (needs all `files` rows).
+        $this->call(EmpodatSuspectDataSourceSeeder::class);
+    }
+}

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectSedimentMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectSedimentMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectSedimentMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g dry weight_1192 - SEDIMENT.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g dry weight_1192 - SEDIMENT.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectSedimentMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectSedimentMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectSedimentMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectSedimentSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectSedimentSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectSedimentSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g dry weight_1192 - SEDIMENT.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_CONNECT 1_suspect screening results_ng g dry weight_1192 - SEDIMENT.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectSedimentXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectSedimentXlsxStationsMappingSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectSedimentXlsxStationsMappingSeeder extends Seeder
         // DB::table($target_table_name)->truncate();
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_CONNECT 1_suspect screening results_ng g dry weight_1192 - SEDIMENT.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_CONNECT 1_suspect screening results_ng g dry weight_1192 - SEDIMENT.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectSusdatCodeMappingsSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectSusdatCodeMappingsSeeder.php
@@ -22,7 +22,7 @@ class EmpodatSuspectSusdatCodeMappingsSeeder extends Seeder
 
         $this->command->info('Seeding code mappings from duplicity_final.csv...');
 
-        $path = base_path('database/seeders/seeds/empodat_suspect/duplicity_final.csv');
+        $path = storage_path('app/public/empodat_suspect/duplicity_final.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemInvertebrateMainSeeder.php
@@ -96,6 +96,7 @@ class EmpodatSuspectTerraChemInvertebrateMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming TerraChem INVERTEBRATE → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemPlantMainSeeder.php
@@ -102,6 +102,7 @@ class EmpodatSuspectTerraChemPlantMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming TerraChem PLANT → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemRodentMainSeeder.php
@@ -97,6 +97,7 @@ class EmpodatSuspectTerraChemRodentMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming TerraChem RODENT → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectTerraChemSoilMainSeeder.php
@@ -96,6 +96,7 @@ class EmpodatSuspectTerraChemSoilMainSeeder extends Seeder
         }
         DB::connection()->disableQueryLog();
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
         $this->command->info('Streaming TerraChem SOIL → empodat_suspect_main + empodat_suspect_metadata + empodat_suspect_substances (file_id='
             .self::FILE_ID.')...');

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectUbaHelcomMainSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectUbaHelcomMainSeeder.php
@@ -48,8 +48,9 @@ class EmpodatSuspectUbaHelcomMainSeeder extends Seeder
 
         // Disable foreign key checks temporarily for faster inserts (PostgreSQL)
         DB::statement('SET session_replication_role = replica;');
+        DB::statement('SET synchronous_commit = off;');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");
@@ -95,7 +96,8 @@ class EmpodatSuspectUbaHelcomMainSeeder extends Seeder
         $this->command->info('Identified '.count($stationColumns).' station columns');
 
         $batch = [];
-        $batchSize = 500;
+        $substances = [];
+        $batchSize = 5000;
         $rowCount = 0;
         $recordCount = 0;
         $skippedRows = 0;
@@ -112,6 +114,16 @@ class EmpodatSuspectUbaHelcomMainSeeder extends Seeder
                 // Test mode row limit
                 if ($this->limitRows && $rowCount >= $this->limitRows) {
                     break;
+                }
+
+                $substanceNormanId = trim((string) ($row['NORMAN_ID'] ?? ''));
+                $substanceName = trim((string) ($row['Name'] ?? ''));
+                if ($substanceNormanId !== '' && $substanceName !== '') {
+                    $substances[$substanceNormanId.'|'.$substanceName] ??= [
+                        'norman_id' => $substanceNormanId,
+                        'name' => $substanceName,
+                        'file_id' => $this->fileId,
+                    ];
                 }
 
                 try {
@@ -160,6 +172,13 @@ class EmpodatSuspectUbaHelcomMainSeeder extends Seeder
                 DB::table($target_table_name)->insert($batch);
                 unset($batch);
                 $batch = [];
+            }
+
+            if (! empty($substances)) {
+                foreach (array_chunk(array_values($substances), 5000) as $substanceChunk) {
+                    DB::table('empodat_suspect_substances')->insert($substanceChunk);
+                }
+                $this->command->info('Inserted '.count($substances).' unique substances (collected in main pass)');
             }
 
             DB::commit();

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectUbaHelcomSubstancesSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectUbaHelcomSubstancesSeeder.php
@@ -24,7 +24,7 @@ class EmpodatSuspectUbaHelcomSubstancesSeeder extends Seeder
         ini_set('memory_limit', '2G');
         ini_set('max_execution_time', '7200');
 
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.xlsx';
+        $path = storage_path('app/public/empodat_suspect/OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.xlsx');
 
         if (! file_exists($path)) {
             $this->command->error("Excel file not found: {$path}");

--- a/database/seeders/EmpodatSuspect/EmpodatSuspectUbaHelcomXlsxStationsMappingSeeder.php
+++ b/database/seeders/EmpodatSuspect/EmpodatSuspectUbaHelcomXlsxStationsMappingSeeder.php
@@ -20,7 +20,7 @@ class EmpodatSuspectUbaHelcomXlsxStationsMappingSeeder extends Seeder
         $target_table_name = 'empodat_suspect_xlsx_stations_mapping';
 
         $now = Carbon::now();
-        $path = base_path().'/database/seeders/seeds/empodat_suspect/headers_OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.csv';
+        $path = storage_path('app/public/empodat_suspect/headers_OK_UBA-HELCOM_suspect screening results_ng g wet weight_1204.csv');
 
         if (! file_exists($path)) {
             $this->command->error("CSV file not found: {$path}");


### PR DESCRIPTION
## Why
The 15 Empodat Suspect source files (file_id 10001–10015) were imported in a chaotic order, and the final TerraChem batch (10012–10015) was imported in parallel. Because `empodat_suspect_main.id` is one shared BIGSERIAL, the parallel runs interleaved their auto-increment ids, leaving the per-file id ranges overlapping and out of order. This branch adds a controlled way to wipe and re-import all sources strictly sequentially so each file occupies one contiguous, non-overlapping block of ids.

## What's in here
- **New `EmpodatSuspectResetAndReseedSeeder`** — interactively confirms, truncates the four per-source data tables (`empodat_suspect_main`, `empodat_suspect_metadata`, `empodat_suspect_substances`, `empodat_suspect_data_source`) with `RESTART IDENTITY`, then re-imports every source one-at-a-time in ascending file_id order. Keeps the `files` rows; does **not** rescan `main_id_from/to` or refresh materialized views (those remain deliberate manual follow-up steps).
- **Storage-path reconciliation** — all legacy Empodat Suspect seeders now read from the persistent `storage/app/public/empodat_suspect/` disk (same convention as the BlackSea/TerraChem seeders) instead of the gitignored `database/seeders/seeds/`. The source files already exist in `shared/storage` on production, so the reseed can run there.
- **Bulk-insert tuning** — main-insert batch sizes raised (legacy 500→5000; newer→4000, kept under PostgreSQL's 65535 bind-parameter limit given the 16-column metadata write) and `SET synchronous_commit = off` during the load.
- **Single-read substance merge** — substance collection is folded into the 8 legacy main seeders so each source file is parsed once instead of twice; the standalone `SubstancesSeeder` calls are removed from the reset orchestrator.

## Testing
Validated locally on the dev database — the pipeline runs end-to-end. After a reseed, `files.main_id_from/to` must be refreshed via the web UI Rescan, and the matrix/filter/prioritisation MVs + statistics regenerated (per the seeder's closing notes).

## Notes
- No migrations in this PR.
- The 8 standalone `*SubstancesSeeder` classes are now unused (dead code) but left in place to keep the diff focused.